### PR TITLE
changes to the project listing as per test feedback

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Models/AutoCompleteSearchModel.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Models/AutoCompleteSearchModel.cs
@@ -5,7 +5,7 @@
 		public AutoCompleteSearchModel(string label, string searchQuery, string searchEndpoint)
 		{
 			Label = label;
-			SearchQuery = searchQuery;
+			SearchQuery = searchQuery?.Replace("'", "\\'");
 			SearchEndpoint = searchEndpoint;
 		}
 

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/InvoluntaryProject/Summary.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/InvoluntaryProject/Summary.cshtml
@@ -51,7 +51,7 @@
                         @Model.Establishment.EstablishmentName
                     </dd>
                     <dd class="govuk-summary-list__actions">
-                        <a asp-page="@Links.InvoluntaryProject.SearchSchool.Page" class="govuk-link"
+                        <a asp-page="@Links.InvoluntaryProject.SearchSchool.Page" class="govuk-link" data-cy="change-school"
                        asp-all-route-data="@backLinkRouteParams">
                             Change<span class="govuk-visually-hidden">School name</span>
                         </a>
@@ -156,7 +156,7 @@
                         @Model.Trust.GroupName
                     </dd>
                     <dd class="govuk-summary-list__actions">
-                        <a a asp-page="@Links.InvoluntaryProject.SearchTrusts.Page" class="govuk-link"
+                        <a asp-page="@Links.InvoluntaryProject.SearchTrusts.Page" class="govuk-link" data-cy="change-trust"
                        asp-all-route-data="@backLinkRouteParams">
                             Change<span class="govuk-visually-hidden">Trust name</span>
                         </a>

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/InvoluntaryProject/_AutoComplete.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/InvoluntaryProject/_AutoComplete.cshtml
@@ -16,21 +16,21 @@
             clearTimeout(timer);
             timer = setTimeout(() => func.apply(this, args), timeout);
         };
-    }
-
-    var loading = true;
+    }    
+    
+    let loading = true;
 
     function suggest(query, populateResults) {
-        var xhttp = new XMLHttpRequest();
-        xhttp.onload = function() {
-           if (!loading || '@Html.Raw(Model.SearchQuery)' == '') populateResults(JSON.parse(this.responseText));
+        const http = new XMLHttpRequest();        
+        http.onload = function() {
+           if (!loading || '@Html.Raw(Model.SearchQuery)' === '') populateResults(JSON.parse(this.responseText));
            loading = false;
         }
-        xhttp.open('GET', `@Html.Raw(Model.SearchEndpoint)${query}`, true);
-        xhttp.send();
+        http.open('GET', `@Html.Raw(Model.SearchEndpoint)${query}`, true);
+        http.send();
     }
 
-    var suggestDebounce = debounce((query, populateResults) => suggest(query, populateResults));
+    const suggestDebounce = debounce((query, populateResults) => suggest(query, populateResults));
 
     accessibleAutocomplete({
         element: document.querySelector('#search'),
@@ -47,5 +47,4 @@
 
     // setting the default option manually due to bug in autoselect - https://github.com/alphagov/accessible-autocomplete/issues/424
     document.querySelector('#SearchQuery').value = '@Html.Raw(Model.SearchQuery)';
-
 </script>

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/ProjectList/Index.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/ProjectList/Index.cshtml
@@ -85,7 +85,7 @@
                                             <strong>
                                                 <a id="@("school-name-" + index)" class="govuk-link" asp-page="@Links.TaskList.Index.Page" asp-route-id="@project.Id">@project.SchoolName</a>
                                             </strong>
-                                            <span id="@("urn-" + index)">URN @project.SchoolURN</span>
+                                            <span id="@("urn-" + index)">URN: @project.SchoolURN</span>
                                         </h2>
                                         <p class="govuk-!-margin-top-3">
                                             <div data-cy="route">Route: @(string.IsNullOrWhiteSpace(project.ApplicationReceivedDate) ? "Involuntary conversion" : "Voluntary conversion")</div>
@@ -111,10 +111,17 @@
                                             </span>
                                             @if (ShowHtbDate(project))
                                             {
-                                                <span id="@("Advisory-Board-date-" + index)">
-                                                    @("Advisory board date: " + project.HeadTeacherBoardDate)<br>
-                                                </span>
-                                                <span id="@("opening-date-" + index)">@("Opening date: " + project.ProposedAcademyOpeningDate)</span>
+                                               <span id="@("Advisory-Board-date-" + index)">
+                                                  @("Advisory board date: " + project.HeadTeacherBoardDate)<br>
+                                               </span>
+                                               <span id="@("opening-date-" + index)">
+                                                  Opening date:
+                                                  @if (string.IsNullOrWhiteSpace(project.ProposedAcademyOpeningDate)) { <span class="empty">EMPTY</span> }
+                                                  else
+                                                  {
+                                                     @project.ProposedAcademyOpeningDate
+                                                  }
+                                               </span>
                                             }
                                         </p>
                                     </td>


### PR DESCRIPTION
Tweak to the display of project listing for empty opening dates.
Bug fix for when a school contains an `'`
Adding data attribute for change links on summary page.