### PR TITLE
Fixed cypress test

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/e2e/Involuntary-project/change-school-and-trust.cy.js
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/e2e/Involuntary-project/change-school-and-trust.cy.js
@@ -16,7 +16,7 @@ Cypress._.each(['ipad-mini'], (viewport) => {
     it('TC01: should update the changed school', () => {
       cy.get('[data-cy="change-school"]').should('be.visible').click();
       cy.wait(500) //need to explicitly wait due to performance issue
-      cy.get('.govuk-label').should('contain', 'What is the school name?');
+      cy.get('.govuk-label').should('contain', 'Which school is involved?');
       cy.get('[id="SearchQuery"]').first().clear();
       cy.get('[id="SearchQuery"]').first().type('lon');
       cy.get('#SearchQuery__option--0').click();
@@ -30,7 +30,7 @@ Cypress._.each(['ipad-mini'], (viewport) => {
       cy.wait(500) //need to explicitly wait due to performance issue
       cy.get('#query-hint').should('contain.text', 'Search by name, UKPRN or Companies House number.')
       cy.url().should('include', '/start-new-project/trust-name?urn')
-      cy.get('.govuk-label').should('contain', 'What is the trust name?');
+      cy.get('.govuk-label').should('contain', 'Which trust is involved?');
       cy.get('[id="SearchQuery"]').first().clear();
       cy.get('[id="SearchQuery"]').first().type('bristol');
       cy.get('#SearchQuery__option--0').click();

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/e2e/Involuntary-project/check-validation.cy.js
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/e2e/Involuntary-project/check-validation.cy.js
@@ -13,7 +13,7 @@ Cypress._.each(['ipad-mini'], (viewport) => {
     });
 
     it('TC01: should display an error message for blank school-name', () => {
-      cy.get('.govuk-label').should('contain', 'What is the school name?')
+      cy.get('.govuk-label').should('contain', 'Which school is involved?')
       cy.get('[data-id="submit"]').click()
       cy.get('[data-cy="error-summary"]')
         .should('contains.text', 'Enter the school name or URN')
@@ -21,7 +21,7 @@ Cypress._.each(['ipad-mini'], (viewport) => {
 
     //skip TC02 as the bug exist
     it.skip('TC02: should display an error message for invalid school-name', () => {
-      cy.get('.govuk-label').should('contain', 'What is the school name?')
+      cy.get('.govuk-label').should('contain', 'Which school is involved?')
       cy.get('[id="SearchQuery"]').first().type('6657££$$')
       cy.get('[data-id="submit"]').click()
       cy.get('[data-cy="error-summary"]')
@@ -30,7 +30,7 @@ Cypress._.each(['ipad-mini'], (viewport) => {
 
     it('TC03: should display an error message for blank trust-name', () => {
       cy.selectSchool()
-      cy.get('.govuk-label').should('contain', 'What is the trust name?')
+      cy.get('.govuk-label').should('contain', 'Which trust is involved?')
       cy.get('[data-id="submit"]').click()
       cy.get('[data-cy="error-summary"]')
         .should('contains.text', 'Enter the Trust name, UKPRN or Companies House number')
@@ -39,7 +39,7 @@ Cypress._.each(['ipad-mini'], (viewport) => {
     it.skip('TC04: should display an error message for invalid trust-name', () => {
       cy.get('[role="button"]').should('contain.text', "Start a new involuntary conversion project")
       cy.get('a[href="/start-new-project/school-name"]').click()
-      cy.get('.govuk-label').should('contain', 'What is the trust name?')
+      cy.get('.govuk-label').should('contain', 'Which trust is involved?')
       cy.get('[id="SearchQuery"]').first().type('aabbcc')
       cy.get('[data-id="submit"]').click()
       cy.get('[data-cy="error-summary"]')


### PR DESCRIPTION
Fixed involuntary conversion cypress tests, which were failing due to the recent text update on the Dev. env.
<img width="653" alt="fix change school text" src="https://user-images.githubusercontent.com/116153732/221185407-096df093-77d4-40fe-8451-c966afad1fc9.png">
<img width="620" alt="fix text for trust" src="https://user-images.githubusercontent.com/116153732/221185442-475bc9bb-eb8f-4926-813c-7f5c57743a33.png">
