### PR TITLE
Revert back to using Secret value for Cypress endpoint

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -104,8 +104,6 @@ jobs:
     needs: [ build-and-push-image, set-env ]
     runs-on: ubuntu-22.04
     environment: ${{ needs.set-env.outputs.environment }}
-    outputs:
-      endpoint: ${{ steps.azure.outputs.endpoint }}
     steps:
       - name: Azure login with ACA credentials
         uses: azure/login@v1
@@ -124,9 +122,6 @@ jobs:
               --resource-group ${{ secrets.CIP_ACA_RESOURCE_GROUP }} \
               --image ${{ secrets.CIP_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.release }} \
               --output none
-            ENDPOINT=$(az afd endpoint list -g ${{ secrets.CIP_ACA_RESOURCE_GROUP }} --profile-name ${{ secrets.CIP_ACA_RESOURCE_GROUP }}cdn --only-show-errors | jq -r '.[] | .hostName')
-            echo "::add-mask::$ENDPOINT"
-            echo "endpoint=https://${ENDPOINT}" >> $GITHUB_OUTPUT
 
   cypress-tests:
     name: Run Cypress Tests
@@ -151,7 +146,7 @@ jobs:
         run: npm install
 
       - name: Run cypress
-        run: npm run cy:run -- --env url='${{ needs.deploy-image.outputs.endpoint }}',authorizationHeader='${{ secrets.CYPRESS_TEST_SECRET }}'
+        run: npm run cy:run -- --env url='${{ secrets.CIP_ENDPOINT }}',authorizationHeader='${{ secrets.CYPRESS_TEST_SECRET }}'
         env:
           db: ${{ secrets.DB_CONNECTION_STRING }}
 


### PR DESCRIPTION
The new secret has been added to the Github repository for all three environments, even though the job will only run on Dev and Test