### PR TITLE
Upload screenshots on previous task failure

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -150,7 +150,9 @@ jobs:
         env:
           db: ${{ secrets.DB_CONNECTION_STRING }}
 
-      - uses: actions/upload-artifact@v1
+      - name: Upload screenshots
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v1
         with:
           name: screenshots-${{ needs.set-env.outputs.environment }}
           path: Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/screenshots


### PR DESCRIPTION
Previously screenshots were not being uploaded when Cypress tests failed. This was because the artefact upload task was not configured to run in a failure scenario. This PR changes the behaviour of the job so that it only runs if Cypress tests fail.