### PR TITLE
Modularise Terraform Vars Key Vault

### DIFF
--- a/terraform.gpaas-azure-migration/README.md
+++ b/terraform.gpaas-azure-migration/README.md
@@ -130,25 +130,18 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.36.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.46.0 |
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v0.14.3 |
+| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v0.14.6 |
+| <a name="module_azurerm_key_vault"></a> [azurerm\_key\_vault](#module\_azurerm\_key\_vault) | github.com/DFE-Digital/terraform-azurerm-key-vault-tfvars | v0.1.1 |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [azurerm_key_vault.tfvars](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
-| [azurerm_key_vault_secret.tfvars](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
-| [azuread_user.key_vault_access](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/user) | data source |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+No resources.
 
 ## Inputs
 

--- a/terraform.gpaas-azure-migration/README.md
+++ b/terraform.gpaas-azure-migration/README.md
@@ -165,6 +165,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 | <a name="input_container_secret_environment_variables"></a> [container\_secret\_environment\_variables](#input\_container\_secret\_environment\_variables) | Container secret environment variables | `map(string)` | n/a | yes |
 | <a name="input_enable_cdn_frontdoor"></a> [enable\_cdn\_frontdoor](#input\_enable\_cdn\_frontdoor) | Enable Azure CDN Front Door. This will use the Container Apps endpoint as the origin. | `bool` | n/a | yes |
 | <a name="input_enable_container_registry"></a> [enable\_container\_registry](#input\_enable\_container\_registry) | Set to true to create a container registry | `bool` | n/a | yes |
+| <a name="input_enable_event_hub"></a> [enable\_event\_hub](#input\_enable\_event\_hub) | Send Azure Container App logs to an Event Hub sink | `bool` | n/a | yes |
 | <a name="input_enable_monitoring"></a> [enable\_monitoring](#input\_enable\_monitoring) | Create an App Insights instance and notification group for the Container App | `bool` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Will be used along with `project_name` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_existing_network_watcher_name"></a> [existing\_network\_watcher\_name](#input\_existing\_network\_watcher\_name) | Use an existing network watcher to add flow logs. | `string` | n/a | yes |

--- a/terraform.gpaas-azure-migration/container-apps-hosting.tf
+++ b/terraform.gpaas-azure-migration/container-apps-hosting.tf
@@ -1,5 +1,5 @@
 module "azure_container_apps_hosting" {
-  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v0.14.3"
+  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v0.14.6"
 
   environment    = local.environment
   project_name   = local.project_name

--- a/terraform.gpaas-azure-migration/container-apps-hosting.tf
+++ b/terraform.gpaas-azure-migration/container-apps-hosting.tf
@@ -10,6 +10,8 @@ module "azure_container_apps_hosting" {
 
   enable_container_registry = local.enable_container_registry
 
+  enable_event_hub = local.enable_event_hub
+
   image_name                             = local.image_name
   container_command                      = local.container_command
   container_secret_environment_variables = local.container_secret_environment_variables

--- a/terraform.gpaas-azure-migration/data.tf
+++ b/terraform.gpaas-azure-migration/data.tf
@@ -1,7 +1,0 @@
-data "azurerm_client_config" "current" {}
-
-data "azuread_user" "key_vault_access" {
-  for_each = local.key_vault_access_users
-
-  user_principal_name = each.value
-}

--- a/terraform.gpaas-azure-migration/key-vault-tfvars-secrets.tf
+++ b/terraform.gpaas-azure-migration/key-vault-tfvars-secrets.tf
@@ -1,54 +1,13 @@
-resource "azurerm_key_vault" "tfvars" {
-  name                       = "${local.environment}${local.project_name}-tfvars"
-  location                   = module.azure_container_apps_hosting.azurerm_resource_group_default.location
-  resource_group_name        = module.azure_container_apps_hosting.azurerm_resource_group_default.name
-  tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "standard"
-  soft_delete_retention_days = 7
-  enable_rbac_authorization  = false
+module "azurerm_key_vault" {
+  source = "github.com/DFE-Digital/terraform-azurerm-key-vault-tfvars?ref=v0.1.1"
 
-  dynamic "access_policy" {
-    for_each = data.azuread_user.key_vault_access
-
-    content {
-      tenant_id = data.azurerm_client_config.current.tenant_id
-      object_id = access_policy.value["object_id"]
-
-      key_permissions = [
-        "Create",
-        "Get",
-      ]
-
-      secret_permissions = [
-        "Set",
-        "Get",
-        "Delete",
-        "Purge",
-        "Recover",
-        "List",
-      ]
-    }
-  }
-
-  # It won't be possible to add/manage a network acl for this
-  # vault, as it will need to be accessable for multiple people.
-  # tfsec:ignore:azure-keyvault-specify-network-acl
-  network_acls {
-    bypass         = "None"
-    default_action = "Allow"
-  }
-
-  purge_protection_enabled = true
-
-  tags = local.tags
-}
-
-# Expiry doesn't need to be set, as this is just used as a way to
-# store and share the tfvars
-# tfsec:ignore:azure-keyvault-ensure-secret-expiry
-resource "azurerm_key_vault_secret" "tfvars" {
-  name         = "${local.environment}${local.project_name}-tfvars"
-  value        = base64encode(file(local.tfvars_filename))
-  key_vault_id = azurerm_key_vault.tfvars.id
-  content_type = "text/plain+base64"
+  environment                           = local.environment
+  project_name                          = local.project_name
+  resource_group_name                   = module.azure_container_apps_hosting.azurerm_resource_group_default.name
+  azure_location                        = local.azure_location
+  key_vault_access_users                = local.key_vault_access_users
+  tfvars_filename                       = local.tfvars_filename
+  diagnostic_log_analytics_workspace_id = module.azure_container_apps_hosting.azurerm_log_analytics_workspace_container_app.id
+  diagnostic_eventhub_name              = local.enable_event_hub ? module.azure_container_apps_hosting.azurerm_eventhub_container_app.name : ""
+  tags                                  = local.tags
 }

--- a/terraform.gpaas-azure-migration/locals.tf
+++ b/terraform.gpaas-azure-migration/locals.tf
@@ -9,6 +9,7 @@ locals {
   container_command                            = var.container_command
   container_secret_environment_variables       = var.container_secret_environment_variables
   container_max_replicas                       = var.container_max_replicas
+  enable_event_hub                             = var.enable_event_hub
   enable_cdn_frontdoor                         = var.enable_cdn_frontdoor
   cdn_frontdoor_enable_rate_limiting           = var.cdn_frontdoor_enable_rate_limiting
   cdn_frontdoor_host_add_response_headers      = var.cdn_frontdoor_host_add_response_headers

--- a/terraform.gpaas-azure-migration/variables.tf
+++ b/terraform.gpaas-azure-migration/variables.tf
@@ -59,6 +59,11 @@ variable "container_max_replicas" {
   type        = number
 }
 
+variable "enable_event_hub" {
+  description = "Send Azure Container App logs to an Event Hub sink"
+  type        = bool
+}
+
 variable "enable_cdn_frontdoor" {
   description = "Enable Azure CDN Front Door. This will use the Container Apps endpoint as the origin."
   type        = bool


### PR DESCRIPTION
What is the change?
Instead of defining all of the terraform for deploying a Key Vault, I have switched to using a terraform module which shifts a lot of the configurable options upstream and reduces the complexity of the terraform code in this repo.

Why do we need the change?
Allows for centralised updates for the Key Vault resource and reduces complexity of the terraform in this repo.

What is the impact?
Applying this terraform change will destroy the existing tfvars Key Vault and recreate it. This has no impact on the running services within Azure and is considered safe/low impact.