### PR TITLE
Added NS record option for delegating subdomains

### DIFF
--- a/terraform.gpaas-azure-migration/README.md
+++ b/terraform.gpaas-azure-migration/README.md
@@ -158,6 +158,7 @@ No resources.
 | <a name="input_container_health_probe_path"></a> [container\_health\_probe\_path](#input\_container\_health\_probe\_path) | Specifies the path that is used to determine the liveness of the Container | `string` | n/a | yes |
 | <a name="input_container_max_replicas"></a> [container\_max\_replicas](#input\_container\_max\_replicas) | Container max replicas | `number` | n/a | yes |
 | <a name="input_container_secret_environment_variables"></a> [container\_secret\_environment\_variables](#input\_container\_secret\_environment\_variables) | Container secret environment variables | `map(string)` | n/a | yes |
+| <a name="input_dns_ns_records"></a> [dns\_ns\_records](#input\_dns\_ns\_records) | DNS NS records to add to the DNS Zone | <pre>map(<br>    object({<br>      ttl : optional(number, 300),<br>      records : list(string)<br>    })<br>  )</pre> | n/a | yes |
 | <a name="input_dns_zone_domain_name"></a> [dns\_zone\_domain\_name](#input\_dns\_zone\_domain\_name) | DNS zone domain name. If created, records will automatically be created to point to the CDN. | `string` | n/a | yes |
 | <a name="input_enable_cdn_frontdoor"></a> [enable\_cdn\_frontdoor](#input\_enable\_cdn\_frontdoor) | Enable Azure CDN Front Door. This will use the Container Apps endpoint as the origin. | `bool` | n/a | yes |
 | <a name="input_enable_container_registry"></a> [enable\_container\_registry](#input\_enable\_container\_registry) | Set to true to create a container registry | `bool` | n/a | yes |

--- a/terraform.gpaas-azure-migration/container-apps-hosting.tf
+++ b/terraform.gpaas-azure-migration/container-apps-hosting.tf
@@ -12,6 +12,7 @@ module "azure_container_apps_hosting" {
 
   enable_dns_zone      = local.enable_dns_zone
   dns_zone_domain_name = local.dns_zone_domain_name
+  dns_ns_records       = local.dns_ns_records
 
   enable_event_hub = local.enable_event_hub
 

--- a/terraform.gpaas-azure-migration/locals.tf
+++ b/terraform.gpaas-azure-migration/locals.tf
@@ -12,6 +12,7 @@ locals {
   enable_event_hub                             = var.enable_event_hub
   enable_dns_zone                              = var.enable_dns_zone
   dns_zone_domain_name                         = var.dns_zone_domain_name
+  dns_ns_records                               = var.dns_ns_records
   enable_cdn_frontdoor                         = var.enable_cdn_frontdoor
   cdn_frontdoor_enable_rate_limiting           = var.cdn_frontdoor_enable_rate_limiting
   cdn_frontdoor_host_add_response_headers      = var.cdn_frontdoor_host_add_response_headers

--- a/terraform.gpaas-azure-migration/variables.tf
+++ b/terraform.gpaas-azure-migration/variables.tf
@@ -153,3 +153,13 @@ variable "cdn_frontdoor_host_redirects" {
   description = "CDN FrontDoor host redirects `[{ \"from\" = \"example.com\", \"to\" = \"www.example.com\" }]`"
   type        = list(map(string))
 }
+
+variable "dns_ns_records" {
+  description = "DNS NS records to add to the DNS Zone"
+  type = map(
+    object({
+      ttl : optional(number, 300),
+      records : list(string)
+    })
+  )
+}


### PR DESCRIPTION
Adding NS records to your primary DNS Zone allows you to delegate records for subdomains into their own individual Zones instead of managing all records in your primary Zone.