### PR TITLE
Feature/129099 remove requests for telephone numbers from the school application page

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/e2e/School-application-form-apply-to-become/apply-to-become-get-application-data-map.cy.js
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/e2e/School-application-form-apply-to-become/apply-to-become-get-application-data-map.cy.js
@@ -1,7 +1,7 @@
 /// <reference types ='Cypress'/>
 import {data} from "../../fixtures/cath121-body.json"
 
-describe('91489: Apply-to-becom GET data application types', () => {
+describe('91489): Apply-to-become GET data application types', () => {
 	let dataAppSch = data.applyingSchools[0]
 
 	beforeEach(() => {
@@ -52,22 +52,18 @@ describe('91489: Apply-to-becom GET data application types', () => {
 		cy.get('[test-id="About_the_conversion_Contact_details1_value"]').should('contain.text', dataAppSch.schoolConversionContactHeadName)
 		cy.get('[test-id="About_the_conversion_Contact_details2_key"]').should('contain.text', "Headteacher's email address")
 		cy.get('[test-id="About_the_conversion_Contact_details2_value"]').should('contain.text', dataAppSch.schoolConversionContactHeadEmail)
-		cy.get('[test-id="About_the_conversion_Contact_details3_key"]').should('contain.text', "Headteacher's phone number")
-		cy.get('[test-id="About_the_conversion_Contact_details3_value"]').should('have.value', '')
-		cy.get('[test-id="About_the_conversion_Contact_details4_key"]').should('contain.text', 'Name of the chair of the Governing Body')
-		cy.get('[test-id="About_the_conversion_Contact_details4_value"]').should('contain.text', dataAppSch.schoolConversionContactChairName)
-		cy.get('[test-id="About_the_conversion_Contact_details5_key"]').should('contain.text', "Chair's email address")
-		cy.get('[test-id="About_the_conversion_Contact_details5_value"]').should('contain.text', dataAppSch.schoolConversionContactChairEmail)
-		cy.get('[test-id="About_the_conversion_Contact_details6_key"]').should('contain.text', "Chair's phone number")
-		cy.get('[test-id="About_the_conversion_Contact_details6_value"]').should('have.value', '')
-		cy.get('[test-id="About_the_conversion_Contact_details7_key"]').should('contain.text', "Who is the main contact for the conversion?")
-		cy.get('[test-id="About_the_conversion_Contact_details7_value"]').should('contain.text', dataAppSch.schoolConversionContactRole)
-		cy.get('[test-id="About_the_conversion_Contact_details8_key"]').should('contain.text', "Main contact's name")
-		cy.get('[test-id="About_the_conversion_Contact_details8_value"]').should('contain.text', dataAppSch.schoolConversionApproverContactName)
+		cy.get('[test-id="About_the_conversion_Contact_details3_key"]').should('contain.text', 'Name of the chair of the Governing Body')
+		cy.get('[test-id="About_the_conversion_Contact_details3_value"]').should('contain.text', dataAppSch.schoolConversionContactChairName)
+		cy.get('[test-id="About_the_conversion_Contact_details4_key"]').should('contain.text', "Chair's email address")
+		cy.get('[test-id="About_the_conversion_Contact_details4_value"]').should('contain.text', dataAppSch.schoolConversionContactChairEmail)
+		cy.get('[test-id="About_the_conversion_Contact_details5_key"]').should('contain.text', "Who is the main contact for the conversion?")
+		cy.get('[test-id="About_the_conversion_Contact_details5_value"]').should('contain.text', dataAppSch.schoolConversionContactRole)
+		cy.get('[test-id="About_the_conversion_Contact_details6_key"]').should('contain.text', "Main contact's name")
+		cy.get('[test-id="About_the_conversion_Contact_details6_value"]').should('contain.text', dataAppSch.schoolConversionApproverContactName)
 	})
 
 	// Date for Conversion
-	it.only('TC05: Date for Conversion', () => {
+	it('TC05: Date for Conversion', () => {
 		cy.get('[test-id="About_the_conversion_Date_for_conversion1_key"]').should('contain.text', 'Do you want the conversion to happen on a particular date')
 		cy.get('[test-id="About_the_conversion_Date_for_conversion1_value"]')
 			.should('contain.text', 'Yes')

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/e2e/School-application-form-apply-to-become/devIntegration-tests.cy.js
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/e2e/School-application-form-apply-to-become/devIntegration-tests.cy.js
@@ -175,10 +175,6 @@ describe('Fetch data from Internal', { tags: ['@integration'] }, () => {
                 }
             })
 
-        cy.get('[test-id="About_the_conversion_Contact_details3_key"]')
-            .should('be.visible')
-            .should('contain.text', "Headteacher's phone number");        
-
         cy.get('[test-id="About_the_conversion_Contact_details4_key"]')
             .should('be.visible')
             .should('contain.text', 'Name of the chair of the Governing Body')
@@ -210,10 +206,6 @@ describe('Fetch data from Internal', { tags: ['@integration'] }, () => {
                     return null
                 }
             })
-
-        cy.get('[test-id="About_the_conversion_Contact_details6_key"]')
-            .should('be.visible')
-            .should('contain.text', "Chair's phone number");
 
         cy.get('[test-id="About_the_conversion_Contact_details7_key"]')
             .should('be.visible')

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/e2e/School-application-form-apply-to-become/stageIntegration-tests.cy.js
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/e2e/School-application-form-apply-to-become/stageIntegration-tests.cy.js
@@ -175,10 +175,6 @@ describe('Fetch data from Internal', { tags: ['@integration'] }, () => {
                 }
             })
 
-        cy.get('[test-id="About_the_conversion_Contact_details3_key"]')
-            .should('be.visible')
-            .should('contain.text', "Headteacher's phone number");
-
         cy.get('[test-id="About_the_conversion_Contact_details4_key"]')
             .should('be.visible')
             .should('contain.text', 'Name of the chair of the Governing Body')
@@ -210,10 +206,6 @@ describe('Fetch data from Internal', { tags: ['@integration'] }, () => {
                     return null
                 }
             })
-
-        cy.get('[test-id="About_the_conversion_Contact_details6_key"]')
-            .should('be.visible')
-            .should('contain.text', "Chair's phone number");
 
         cy.get('[test-id="About_the_conversion_Contact_details7_key"]')
             .should('be.visible')

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/fixtures/cath121-body.json
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/fixtures/cath121-body.json
@@ -47,7 +47,6 @@
             "schoolConversionContactRole": "Other",
             "schoolConversionMainContactOtherName": "cZHTXOWnKgjYOV ",
             "schoolConversionMainContactOtherEmail": "fceqcdamolovrafloutikdjujkfaxqbxkjk@mymfq.com",
-            "schoolConversionMainContactOtherTelephone": "77744625023",
             "schoolConversionMainContactOtherRole": "dmvtX",
             "schoolConversionApproverContactName": "cZHTXOWnKgjYOV",
             "schoolConversionApproverContactEmail": "cbsefqvcqyptjiyxjmejdqzwi@yqqis.com",

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/fixtures/devProject-body.json
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/fixtures/devProject-body.json
@@ -59,7 +59,6 @@
                 "schoolConversionContactRole": "Headteacher",
                 "schoolConversionMainContactOtherName": "Jeanne_Doe47",
                 "schoolConversionMainContactOtherEmail": "Jeanne86@example.fakerjs.dev",
-                "schoolConversionMainContactOtherTelephone": "+44 20 824 21 35",
                 "schoolConversionMainContactOtherRole": "Nulla aut sed.",
                 "schoolConversionApproverContactName": "ApproverFullName",
                 "schoolConversionApproverContactEmail": "ApproverEmailAddress@test.com",

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/fixtures/stagingProject-body.json
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/fixtures/stagingProject-body.json
@@ -59,7 +59,6 @@
                 "schoolConversionContactRole": "Headteacher",
                 "schoolConversionMainContactOtherName": "Jeanne_Doe47",
                 "schoolConversionMainContactOtherEmail": "Jeanne86@example.fakerjs.dev",
-                "schoolConversionMainContactOtherTelephone": "+44 20 824 21 35",
                 "schoolConversionMainContactOtherRole": "Nulla aut sed.",
                 "schoolConversionApproverContactName": "ApproverFullName",
                 "schoolConversionApproverContactEmail": "ApproverEmailAddress@test.com",

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.Data.Tests/Models/AcademisationApplication/PopulateSchoolDetailsTests.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.Data.Tests/Models/AcademisationApplication/PopulateSchoolDetailsTests.cs
@@ -17,14 +17,11 @@ public class PopulateSchoolDetailsTests
          SchoolName = "Old School Name",
          SchoolConversionContactHeadName = "Head Name",
          SchoolConversionContactHeadEmail = "head@email.com",
-         SchoolConversionContactHeadTel = "1234567890",
          SchoolConversionContactRole = "Role",
          SchoolConversionContactChairName = "Chair Name",
          SchoolConversionContactChairEmail = "chair@email.com",
-         SchoolConversionContactChairTel = "0987654321",
          SchoolConversionMainContactOtherName = "Other Name",
          SchoolConversionMainContactOtherEmail = "other@email.com",
-         SchoolConversionMainContactOtherTelephone = "1111111111",
          SchoolConversionApproverContactName = "Approver Name",
          SchoolConversionApproverContactEmail = "approver@email.com",
          SchoolConversionTargetDateSpecified = true,
@@ -44,14 +41,11 @@ public class PopulateSchoolDetailsTests
       Assert.Equal("Old School Name", academiesApplicationSchool.SchoolName);
       Assert.Equal("Head Name", academiesApplicationSchool.SchoolConversionContactHeadName);
       Assert.Equal("head@email.com", academiesApplicationSchool.SchoolConversionContactHeadEmail);
-      Assert.Equal("1234567890", academiesApplicationSchool.SchoolConversionContactHeadTel);
       Assert.Equal("Role", academiesApplicationSchool.SchoolConversionContactRole);
       Assert.Equal("Chair Name", academiesApplicationSchool.SchoolConversionContactChairName);
       Assert.Equal("chair@email.com", academiesApplicationSchool.SchoolConversionContactChairEmail);
-      Assert.Equal("0987654321", academiesApplicationSchool.SchoolConversionContactChairTel);
       Assert.Equal("Other Name", academiesApplicationSchool.SchoolConversionMainContactOtherName);
       Assert.Equal("other@email.com", academiesApplicationSchool.SchoolConversionMainContactOtherEmail);
-      Assert.Equal("1111111111", academiesApplicationSchool.SchoolConversionMainContactOtherTelephone);
       Assert.Equal("Approver Name", academiesApplicationSchool.SchoolConversionApproverContactName);
       Assert.Equal("approver@email.com", academiesApplicationSchool.SchoolConversionApproverContactEmail);
       Assert.True(academiesApplicationSchool.SchoolConversionTargetDateSpecified);

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Models/AcademisationApplication/AcademisationApplication.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Models/AcademisationApplication/AcademisationApplication.cs
@@ -282,22 +282,16 @@ public class AcademisationApplication
          academisationApplicationSchool.SchoolConversionContactHeadName;
       academiesApplicationSchool.SchoolConversionContactHeadEmail =
          academisationApplicationSchool.SchoolConversionContactHeadEmail;
-      academiesApplicationSchool.SchoolConversionContactHeadTel =
-         academisationApplicationSchool.SchoolConversionContactHeadTel;
       academiesApplicationSchool.SchoolConversionContactRole =
          academisationApplicationSchool.SchoolConversionContactRole;
       academiesApplicationSchool.SchoolConversionContactChairName =
          academisationApplicationSchool.SchoolConversionContactChairName;
       academiesApplicationSchool.SchoolConversionContactChairEmail =
          academisationApplicationSchool.SchoolConversionContactChairEmail;
-      academiesApplicationSchool.SchoolConversionContactChairTel =
-         academisationApplicationSchool.SchoolConversionContactChairTel;
       academiesApplicationSchool.SchoolConversionMainContactOtherName =
          academisationApplicationSchool.SchoolConversionMainContactOtherName;
       academiesApplicationSchool.SchoolConversionMainContactOtherEmail =
          academisationApplicationSchool.SchoolConversionMainContactOtherEmail;
-      academiesApplicationSchool.SchoolConversionMainContactOtherTelephone =
-         academisationApplicationSchool.SchoolConversionMainContactOtherTelephone;
       academiesApplicationSchool.SchoolConversionApproverContactName =
          academisationApplicationSchool.SchoolConversionApproverContactName;
       academiesApplicationSchool.SchoolConversionApproverContactEmail =

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Models/AcademisationApplication/School.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Models/AcademisationApplication/School.cs
@@ -31,14 +31,11 @@ public class School
    public List<Lease> Leases { get; set; }
    public string SchoolConversionContactHeadName { get; set; }
    public string SchoolConversionContactHeadEmail { get; set; }
-   public string SchoolConversionContactHeadTel { get; set; }
    public string SchoolConversionContactChairName { get; set; }
    public string SchoolConversionContactChairEmail { get; set; }
-   public string SchoolConversionContactChairTel { get; set; }
    public string SchoolConversionContactRole { get; set; }
    public string SchoolConversionMainContactOtherName { get; set; }
    public string SchoolConversionMainContactOtherEmail { get; set; }
-   public string SchoolConversionMainContactOtherTelephone { get; set; }
    public string SchoolConversionMainContactOtherRole { get; set; }
    public string SchoolConversionApproverContactName { get; set; }
    public string SchoolConversionApproverContactEmail { get; set; }

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Models/Application/ApplyingSchool.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Models/Application/ApplyingSchool.cs
@@ -13,14 +13,11 @@ public class ApplyingSchool
    // contact details
    public string SchoolConversionContactHeadName { get; set; }
    public string SchoolConversionContactHeadEmail { get; set; }
-   public string SchoolConversionContactHeadTel { get; set; }
    public string SchoolConversionContactChairName { get; set; }
    public string SchoolConversionContactChairEmail { get; set; }
-   public string SchoolConversionContactChairTel { get; set; }
    public string SchoolConversionContactRole { get; set; } // "headteacher", "chair of governing body", "someone else"
    public string SchoolConversionMainContactOtherName { get; set; }
    public string SchoolConversionMainContactOtherEmail { get; set; }
-   public string SchoolConversionMainContactOtherTelephone { get; set; }
    public string SchoolConversionMainContactOtherRole { get; set; }
    public string SchoolConversionApproverContactName { get; set; }
 

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Models/Application/ContactDetails.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Models/Application/ContactDetails.cs
@@ -4,5 +4,4 @@ public class ContactDetails
 {
    public string Name { get; set; }
    public string EmailAddress { get; set; }
-   public string TelephoneNumber { get; set; }
 }

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.Tests/Models/ApplicationForm/Sections/AboutConversionSectionTests.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.Tests/Models/ApplicationForm/Sections/AboutConversionSectionTests.cs
@@ -29,14 +29,11 @@ public class AboutConversionSectionTests
       FormField[] expectedFieldsContactDetails = {
          new("Name of headteacher", application.SchoolConversionContactHeadName),
          new("Headteacher's email address", application.SchoolConversionContactHeadEmail),
-         new("Headteacher's phone number", application.SchoolConversionContactHeadTel),
          new("Name of the chair of the Governing Body", application.SchoolConversionContactChairName),
          new("Chair's email address", application.SchoolConversionContactChairEmail),
-         new("Chair's phone number", application.SchoolConversionContactChairTel),
          new("Who is the main contact for the conversion?", application.SchoolConversionContactRole),
          new("Main contact's name", application.SchoolConversionMainContactOtherName),
          new("Main contact's email address", application.SchoolConversionMainContactOtherEmail),
-         new("Main contact's phone number", application.SchoolConversionMainContactOtherTelephone),
          new("Main contact's role", application.SchoolConversionMainContactOtherRole),
          new("Approver's name", application.SchoolConversionApproverContactName),
          new("Approver's email address", application.SchoolConversionApproverContactEmail)
@@ -79,10 +76,8 @@ public class AboutConversionSectionTests
       FormField[] expectedFieldsContactDetails = {
          new("Name of headteacher", application.SchoolConversionContactHeadName),
          new("Headteacher's email address", application.SchoolConversionContactHeadEmail),
-         new("Headteacher's phone number", application.SchoolConversionContactHeadTel),
          new("Name of the chair of the Governing Body", application.SchoolConversionContactChairName),
          new("Chair's email address", application.SchoolConversionContactChairEmail),
-         new("Chair's phone number", application.SchoolConversionContactChairTel),
          new("Who is the main contact for the conversion?", application.SchoolConversionContactRole),
          new("Approver's name", application.SchoolConversionApproverContactName),
          new("Approver's email address", application.SchoolConversionApproverContactEmail)
@@ -125,10 +120,8 @@ public class AboutConversionSectionTests
       FormField[] expectedFieldsContactDetails = {
          new("Name of headteacher", application.SchoolConversionContactHeadName),
          new("Headteacher's email address", application.SchoolConversionContactHeadEmail),
-         new("Headteacher's phone number", application.SchoolConversionContactHeadTel),
          new("Name of the chair of the Governing Body", application.SchoolConversionContactChairName),
          new("Chair's email address", application.SchoolConversionContactChairEmail),
-         new("Chair's phone number", application.SchoolConversionContactChairTel),
          new("Who is the main contact for the conversion?", application.SchoolConversionContactRole),
          new("Approver's name", application.SchoolConversionApproverContactName),
          new("Approver's email address", application.SchoolConversionApproverContactEmail)

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.sln
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.sln
@@ -17,6 +17,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dfe.PrepareConversions.Docu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dfe.PrepareConversions.Redirector", "Dfe.PrepareConversions.Redirector\Dfe.PrepareConversions.Redirector.csproj", "{600F77EC-B7C5-49E0-9488-04ED4A5BC36F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AC81ED86-8D07-46AB-B0AF-A0363E182835}"
+	ProjectSection(SolutionItems) = preProject
+		..\release-notes.md = ..\release-notes.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Models/ApplicationForm/Sections/AboutConversionSection.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Models/ApplicationForm/Sections/AboutConversionSection.cs
@@ -28,16 +28,13 @@ public class AboutConversionSection : BaseFormSection
       List<FormField> formFields = new();
       formFields.Add(new FormField("Name of headteacher", application.SchoolConversionContactHeadName));
       formFields.Add(new FormField("Headteacher's email address", application.SchoolConversionContactHeadEmail));
-      formFields.Add(new FormField("Headteacher's phone number", application.SchoolConversionContactHeadTel));
       formFields.Add(new FormField("Name of the chair of the Governing Body", application.SchoolConversionContactChairName));
       formFields.Add(new FormField("Chair's email address", application.SchoolConversionContactChairEmail));
-      formFields.Add(new FormField("Chair's phone number", application.SchoolConversionContactChairTel));
       formFields.Add(new FormField("Who is the main contact for the conversion?", application.SchoolConversionContactRole));
       if (application.SchoolConversionContactRole is not null && application.SchoolConversionContactRole.ToUpper() == "OTHER")
       {
          formFields.Add(new FormField("Main contact's name", application.SchoolConversionMainContactOtherName));
          formFields.Add(new FormField("Main contact's email address", application.SchoolConversionMainContactOtherEmail));
-         formFields.Add(new FormField("Main contact's phone number", application.SchoolConversionMainContactOtherTelephone));
          formFields.Add(new FormField("Main contact's role", application.SchoolConversionMainContactOtherRole));
       }
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,12 +1,12 @@
 ## 1.1.1
 * Error messages relating to date now formatted with sentence case
 * Error page tab title now displaying
-
+* Telephone numbers for contact details on the school application form page have been removed inline with removing them from the data returned by the academisation API.
 ___
 ## 1.1.0 
 * Flexible Advisory Board Dates: Users can now set advisory board dates in either the future or the past for better planning and tracking.
-* Project listing page now states Project route: Voluntary/Form a MAT and Involuntary (Involuntary is due to change to ‘Sponsored’ and won’t appear in live until the feature is complete)
-* Status tags on Key Stage performance data – Provisional, Revised and Final: This provides much needed context, allowing users to make any informed decisions with the knowledge of whether the data is still subject to change.
+* Project listing page now states Project route: Voluntary/Form a MAT and Involuntary (Involuntary is due to change to ï¿½Sponsoredï¿½ and wonï¿½t appear in live until the feature is complete)
+* Status tags on Key Stage performance data ï¿½ Provisional, Revised and Final: This provides much needed context, allowing users to make any informed decisions with the knowledge of whether the data is still subject to change.
 * New domains introduced:
    * https://www.prepare-conversions.education.gov.uk (Production)
    * https://dev.prepare-conversions.education.gov.uk/ (Development)

--- a/release-notes.md
+++ b/release-notes.md
@@ -5,7 +5,7 @@
 ___
 ## 1.1.0 
 * Flexible Advisory Board Dates: Users can now set advisory board dates in either the future or the past for better planning and tracking.
-* Project listing page now states Project route: Voluntary/Form a MAT and Involuntary (Involuntary is due to change to �Sponsored� and won�t appear in live until the feature is complete)
+* Project listing page now states Project route: Voluntary/Form a MAT and Involuntary (Involuntary is due to change to 'Sponsored' and won't appear in live until the feature is complete)
 * Status tags on Key Stage performance data � Provisional, Revised and Final: This provides much needed context, allowing users to make any informed decisions with the knowledge of whether the data is still subject to change.
 * New domains introduced:
    * https://www.prepare-conversions.education.gov.uk (Production)


### PR DESCRIPTION
Removing Head teacher's telephone number, Chair's telephone number and Main contact's telephone number from the School Application page.

Story :
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Apply%20and%20Prepare/Stories/?workitem=129099