### PR TITLE
Feature/120665 preview proj template for inv conversion

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Models/AcademyTypeAndRoutes.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Models/AcademyTypeAndRoutes.cs
@@ -8,8 +8,8 @@ namespace Dfe.PrepareConversions.Data.Models
 {
    public static class AcademyTypeAndRoutes
    {
-      public static readonly string Voluntary = "Converter";
-      public static readonly string FormAMat = "Form a MAT";
-      public static readonly string Sponsored = "Sponsored";
+      public const string Voluntary = "Converter";
+      public const string FormAMat = "Form a MAT";
+      public const string Sponsored = "Sponsored";
    }
 }

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.Tests/Pages/TaskList/PreviewProjectTemplateTests.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.Tests/Pages/TaskList/PreviewProjectTemplateTests.cs
@@ -1,0 +1,67 @@
+﻿using Dfe.PrepareConversions.Data.Models;
+using FluentAssertions;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Dfe.PrepareConversions.Tests.Pages.TaskList;
+
+public class PreviewProjectTemplateTests : BaseIntegrationTests
+{
+   public PreviewProjectTemplateTests(IntegrationTestingWebApplicationFactory factory) : base(factory) { }
+
+   [Fact]
+   public async Task Given_InvoluntaryConversion_When_Previewed_Then_RationaleForProject_Is_Hidden()
+   {
+      void PostProjectSetup(AcademyConversionProject project)
+      {
+         project.AcademyTypeAndRoute = AcademyTypeAndRoutes.Sponsored;
+      }
+
+      AcademyConversionProject project = AddGetProject(PostProjectSetup);
+      await OpenAndConfirmPathAsync($"/task-list/{project.Id}/preview-project-template");
+      Document.QuerySelector("#rationale-for-project").Should().BeNull();
+   }
+
+   [Fact]
+   public async Task Given_InvoluntaryConversion_When_Previewed_Then_LegalRequirements_Are_Hidden()
+   {
+      void PostProjectSetup(AcademyConversionProject project)
+      {
+         project.AcademyTypeAndRoute = AcademyTypeAndRoutes.Sponsored;
+      }
+
+      AcademyConversionProject project = AddGetProject(PostProjectSetup);
+      await OpenAndConfirmPathAsync($"/task-list/{project.Id}/preview-project-template");
+      Document.QuerySelector("#legal-requirements-heading").Should().BeNull();
+   }
+
+   [Theory]
+   [InlineData(AcademyTypeAndRoutes.Voluntary)]
+   [InlineData(AcademyTypeAndRoutes.FormAMat)]
+   public async Task Given_Not_InvoluntaryConversion_When_Previewed_Then_LegalRequirements_Are_Shown(string routeToConversion)
+   {
+      void PostProjectSetup(AcademyConversionProject project)
+      {
+         project.AcademyTypeAndRoute = routeToConversion;
+      }
+
+      AcademyConversionProject project = AddGetProject(PostProjectSetup);
+      await OpenAndConfirmPathAsync($"/task-list/{project.Id}/preview-project-template");
+      Document.QuerySelector("#legal-requirements-heading").Should().NotBeNull();
+   }
+
+   [Theory]
+   [InlineData(AcademyTypeAndRoutes.Voluntary)]
+   [InlineData(AcademyTypeAndRoutes.FormAMat)]
+   public async Task Given_Not_InvoluntaryConversion_When_Previewed_Then_RationaleForProject_Is_Shown(string routeToConversion)
+   {
+      void PostProjectSetup(AcademyConversionProject project)
+      {
+         project.AcademyTypeAndRoute = routeToConversion;
+      }
+
+      AcademyConversionProject project = AddGetProject(PostProjectSetup);
+      await OpenAndConfirmPathAsync($"/task-list/{project.Id}/preview-project-template");
+      Document.QuerySelector("#rationale-for-project").Should().NotBeNull();
+   }
+}

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/TaskList/PreviewProjectTemplate.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/TaskList/PreviewProjectTemplate.cshtml
@@ -72,7 +72,10 @@
    </header>
    <div class="app-summary-card__body">
       <dl class="govuk-summary-list">
-         <govuk-summary-list-row name="rationale-for-project" key-width="@WidthOverride.OneQuarter" value-width="@WidthOverride.Full" label="Rationale for project" value="@Model.Project.RationaleForProject" asp-page="@Links.RationaleSection.RationaleForProject.Page" asp-route-id="@Model.Project.Id" hidden-text="project rationale"/>
+         @if (!Model.Project.IsSponsored)
+         {
+            <govuk-summary-list-row name="rationale-for-project" key-width="@WidthOverride.OneQuarter" value-width="@WidthOverride.Full" label="Rationale for project" value="@Model.Project.RationaleForProject" asp-page="@Links.RationaleSection.RationaleForProject.Page" asp-route-id="@Model.Project.Id" hidden-text="project rationale"/>
+         }
          <govuk-summary-list-row name="rationale-for-trust" key-width="@WidthOverride.OneQuarter" value-width="@WidthOverride.Full" label="Rationale for the trust or sponsor" value="@Model.Project.RationaleForTrust" asp-page="@Links.RationaleSection.RationaleForTrust.Page" asp-route-id="@Model.Project.Id" hidden-text="sponsor rationale"/>
       </dl>
    </div>
@@ -93,22 +96,25 @@
    </div>
 </section>
 
-<h2 class="govuk-heading-s">Legal requirements</h2>
-<section class="app-summary-card govuk-!-margin-bottom-6">
-   <header class="app-summary-card__header">
-      <h2 class="app-summary-card__title">
-         Legal requirement details
-      </h2>
-   </header>
-   <div class="app-summary-card__body">
-      <dl class="govuk-summary-list">
-         <govuk-summary-list-row name="governing-body-resolution" label="Governing Body Resolution" asp-route-id="@Model.Project.Id" value="@Model.Project.GoverningBodyResolution.SplitPascalCase()" asp-page="@Links.LegalRequirements.GoverningBodyResolution.Page" hidden-text="governing-body-resolution"/>
-         <govuk-summary-list-row name="consultation" label="Consultation" asp-route-id="@Model.Project.Id" value="@Model.Project.Consultation.SplitPascalCase()" asp-page="@Links.LegalRequirements.Consultation.Page" hidden-text="consultation"/>
-         <govuk-summary-list-row name="diocesan-consent" label="Diocesan Consent" asp-route-id="@Model.Project.Id" value="@Model.Project.DiocesanConsent.SplitPascalCase()" asp-page="@Links.LegalRequirements.DiocesanConsent.Page" hidden-text="diocesan-consent"/>
-         <govuk-summary-list-row name="foundation-consent" label="Foundation Consent" asp-route-id="@Model.Project.Id" value="@Model.Project.FoundationConsent.SplitPascalCase()" asp-page="@Links.LegalRequirements.FoundationConsent.Page" hidden-text="foundation-consent"/>
-      </dl>
-   </div>
-</section>
+@if (!Model.Project.IsSponsored)
+{
+   <h2 class="govuk-heading-s">Legal requirements</h2>
+   <section class="app-summary-card govuk-!-margin-bottom-6">
+      <header class="app-summary-card__header">
+         <h2 class="app-summary-card__title">
+            Legal requirement details
+         </h2>
+      </header>
+      <div class="app-summary-card__body">
+         <dl class="govuk-summary-list">
+            <govuk-summary-list-row name="governing-body-resolution" label="Governing Body Resolution" asp-route-id="@Model.Project.Id" value="@Model.Project.GoverningBodyResolution.SplitPascalCase()" asp-page="@Links.LegalRequirements.GoverningBodyResolution.Page" hidden-text="governing-body-resolution"/>
+            <govuk-summary-list-row name="consultation" label="Consultation" asp-route-id="@Model.Project.Id" value="@Model.Project.Consultation.SplitPascalCase()" asp-page="@Links.LegalRequirements.Consultation.Page" hidden-text="consultation"/>
+            <govuk-summary-list-row name="diocesan-consent" label="Diocesan Consent" asp-route-id="@Model.Project.Id" value="@Model.Project.DiocesanConsent.SplitPascalCase()" asp-page="@Links.LegalRequirements.DiocesanConsent.Page" hidden-text="diocesan-consent"/>
+            <govuk-summary-list-row name="foundation-consent" label="Foundation Consent" asp-route-id="@Model.Project.Id" value="@Model.Project.FoundationConsent.SplitPascalCase()" asp-page="@Links.LegalRequirements.FoundationConsent.Page" hidden-text="foundation-consent"/>
+         </dl>
+      </div>
+   </section>
+}
 
 <h2 class="govuk-heading-s">School budget information</h2>
 <section class="app-summary-card govuk-!-margin-bottom-6">

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/TaskList/PreviewProjectTemplate.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/TaskList/PreviewProjectTemplate.cshtml
@@ -98,7 +98,7 @@
 
 @if (!Model.Project.IsSponsored)
 {
-   <h2 class="govuk-heading-s">Legal requirements</h2>
+   <h2 class="govuk-heading-s" id="legal-requirements-heading">Legal requirements</h2>
    <section class="app-summary-card govuk-!-margin-bottom-6">
       <header class="app-summary-card__header">
          <h2 class="app-summary-card__title">


### PR DESCRIPTION
# 120665 - Development: Create preview project template for an involuntary conversion

Most of the requirements on this story already seemed to be done.
Added hiding 'rationale-for-project' and 'Legal requirement details' when project is involuntary conversion.

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Apply%20and%20Prepare/Stories/?workitem=120665

Note the order of fields on the page differs from the story, which also differs from the mockup.
Order of fields hasn't been changed by this work.