### PR TITLE
Fixed response expecting ApiV2Wrapper instead of just object when get…

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Services/ApplicationRepository.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Services/ApplicationRepository.cs
@@ -31,9 +31,8 @@ public class ApplicationRepository
       {
          if (_useAcademisationApplication)
          {
-            ApiV2Wrapper<AcademisationApplication> academisationOuterResponse = await response.Content.ReadFromJsonAsync<ApiV2Wrapper<AcademisationApplication>>();
-            Application academisationResponse = AcademisationApplication.MapToApplication(academisationOuterResponse.Data, schoolName);
-            return new ApiResponse<Application>(response.StatusCode, academisationResponse);
+            AcademisationApplication academisationOuterResponse = await response.Content.ReadFromJsonAsync<AcademisationApplication>();
+            return new ApiResponse<Application>(response.StatusCode, AcademisationApplication.MapToApplication(academisationOuterResponse, schoolName));
          }
 
          ApiV2Wrapper<Application> outerResponse = await response.Content.ReadFromJsonAsync<ApiV2Wrapper<Application>>();

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.Tests/Pages/BaseIntegrationTests.MockData.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.Tests/Pages/BaseIntegrationTests.MockData.cs
@@ -195,8 +195,8 @@ public abstract partial class BaseIntegrationTests
       AcademisationApplication application = _fixture.Create<AcademisationApplication>();
       postSetup?.Invoke(application);
 
-      ApiV2Wrapper<AcademisationApplication> response = new() { Data = application };
-      _factory.AddGetWithJsonResponse(string.Format(_pathFor.GetApplicationByReference, application.ApplicationReference), response);
+      //ApiV2Wrapper<AcademisationApplication> response = new() { Data = application };
+      _factory.AddGetWithJsonResponse(string.Format(_pathFor.GetApplicationByReference, application.ApplicationReference), application);
       return application;
    }
 

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.Tests/Pages/BaseIntegrationTests.MockData.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.Tests/Pages/BaseIntegrationTests.MockData.cs
@@ -2,7 +2,6 @@
 using AutoFixture.Dsl;
 using Dfe.PrepareConversions.Data.Models;
 using Dfe.PrepareConversions.Data.Models.AcademisationApplication;
-using Dfe.PrepareConversions.Data.Models.Application;
 using Dfe.PrepareConversions.Data.Models.Establishment;
 using Dfe.PrepareConversions.Data.Models.KeyStagePerformance;
 using Dfe.PrepareConversions.Data.Services;
@@ -37,7 +36,8 @@ public abstract partial class BaseIntegrationTests
 
       ApiV2Wrapper<IEnumerable<AcademyConversionProject>> response = new()
       {
-         Data = projects, Paging = new ApiV2PagingInfo { RecordCount = recordCount ?? projects.Count, Page = 0 }
+         Data = projects,
+         Paging = new ApiV2PagingInfo { RecordCount = recordCount ?? projects.Count, Page = 0 }
       };
 
       searchModel ??= new AcademyConversionSearchModel
@@ -58,7 +58,8 @@ public abstract partial class BaseIntegrationTests
    {
       ProjectFilterParameters filterParameters = new()
       {
-         Statuses = new List<string> { "Accepted", "Accepted with Conditions", "Deferred", "Declined" }, AssignedUsers = new List<string> { "Bob" }
+         Statuses = new List<string> { "Accepted", "Accepted with Conditions", "Deferred", "Declined" },
+         AssignedUsers = new List<string> { "Bob" }
       };
 
 
@@ -195,7 +196,6 @@ public abstract partial class BaseIntegrationTests
       AcademisationApplication application = _fixture.Create<AcademisationApplication>();
       postSetup?.Invoke(application);
 
-      //ApiV2Wrapper<AcademisationApplication> response = new() { Data = application };
       _factory.AddGetWithJsonResponse(string.Format(_pathFor.GetApplicationByReference, application.ApplicationReference), application);
       return application;
    }


### PR DESCRIPTION
Changed method that fetched project by id from academisation API to expect just the object instead of ApiV2Wrapper<T>
Tests were passing but actual API doesn't return the wrapper so system would fail to deseriliaze the response.