### PR TITLE
UI change to hide the local authority row if it is null or empty

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/FormAMatProjectListRow.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/FormAMatProjectListRow.cshtml
@@ -11,7 +11,10 @@
       <p class="govuk-!-margin-top-3">
          <div data-cy="route">Route: @Model.Item.TypeAndRoute.RouteDescription()</div>
          <div id="@("application-to-join-trust-" + Model.Index)">Application to join a trust: @Model.Item.NameOfTrust</div>
-         <div id="@("local-authority-" + Model.Index)">Local authority: @Model.Item.LocalAuthority</div>
+         @if (@Model.Item.LocalAuthority.IsEmpty() is false)
+         {
+            <div id="@("local-authority-" + Model.Index)">Local authority: @Model.Item.LocalAuthority</div>
+         }
       </p>
    </td>
    <td class="govuk-table__cell govuk-table__cell prepare-text-align-right">

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/SponsoredProjectListRow.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/SponsoredProjectListRow.cshtml
@@ -11,7 +11,11 @@
       <p class="govuk-!-margin-top-3">
          <div data-cy="route">Route: @Model.Item.TypeAndRoute.RouteDescription()</div>
          <div id="@("application-to-join-trust-" + Model.Index)">Application to join a trust: @Model.Item.NameOfTrust</div>
-         <div id="@("local-authority-" + Model.Index)">Local authority: @Model.Item.LocalAuthority</div>
+
+         @if (@Model.Item.LocalAuthority.IsEmpty() is false)
+         {
+            <div id="@("local-authority-" + Model.Index)">Local authority: @Model.Item.LocalAuthority</div>
+         }
          <div id="@("delivery-officer-" + Model.Index)" class="do">
             Delivery officer:
             <span if="Model.Item.AssignedUserFullName.IsEmpty()" class="empty">Empty</span>

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/VoluntaryProjectListRow.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/VoluntaryProjectListRow.cshtml
@@ -11,7 +11,10 @@
       <p class="govuk-!-margin-top-3">
          <div data-cy="route">Route: @Model.Item.TypeAndRoute.RouteDescription()</div>
          <div id="@("application-to-join-trust-" + Model.Index)">Application to join a trust: @Model.Item.NameOfTrust</div>
-         <div id="@("local-authority-" + Model.Index)">Local authority: @Model.Item.LocalAuthority</div>
+         @if (@Model.Item.LocalAuthority.IsEmpty() is false)
+         {
+            <div id="@("local-authority-" + Model.Index)">Local authority: @Model.Item.LocalAuthority</div>
+         }
          <div id="@("delivery-officer-" + Model.Index)" class="do">
             Delivery officer:
             <span if="Model.Item.AssignedUserFullName.IsEmpty()" class="empty">Empty</span>


### PR DESCRIPTION
UI change to hide the local authority row if it is null or empty.
Will re-appear if the data is eventually populated AND the user refreshes the page