### PR TITLE
Added local authority and region to the model sent to academisation api

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Models/Establishment/EstablishmentResponse.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Models/Establishment/EstablishmentResponse.cs
@@ -31,7 +31,7 @@ public class EstablishmentResponse
 
    public class Region
    {
-      public string? Name { get; set; }
+      public string Name { get; set; }
    }
 }
 

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Models/Establishment/EstablishmentResponse.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Models/Establishment/EstablishmentResponse.cs
@@ -26,6 +26,13 @@ public class EstablishmentResponse
    public AddressResponse Address { get; set; }
    public ViewAcademyConversion ViewAcademyConversion { get; set; }
    public string OpenDate { get; set; }
+   
+   public Region Gor { get; set; }
+
+   public class Region
+   {
+      public string? Name { get; set; }
+   }
 }
 
 public class ViewAcademyConversion

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Models/SponsoredProject/CreateSponsoredProject.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.Data/Models/SponsoredProject/CreateSponsoredProject.cs
@@ -4,4 +4,4 @@ public record CreateSponsoredProject(SponsoredProjectSchool School, SponsoredPro
 
 public record SponsoredProjectTrust(string Name, string ReferenceNumber);
 
-public record SponsoredProjectSchool(string Name, string Urn, bool PartOfPfiScheme);
+public record SponsoredProjectSchool(string Name, string Urn, bool PartOfPfiScheme, string LocalAuthorityName, string Region);

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.Tests/Mappings/CreateSponsoredProjectMapperTests.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.Tests/Mappings/CreateSponsoredProjectMapperTests.cs
@@ -1,0 +1,99 @@
+﻿using AutoFixture;
+using Dfe.PrepareConversions.Data.Models.Establishment;
+using Dfe.PrepareConversions.Data.Models.Trust;
+using Dfe.PrepareConversions.Mappings;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using System;
+using Xunit;
+
+namespace Dfe.PrepareConversions.Tests.Mappings;
+
+public class CreateSponsoredProjectMapperTests
+{
+   [Fact]
+   public void Should_Map_Establishment_With_PfiScheme_And_Trust_Into_Dto_CreateSponsoredProject()
+   {
+      // Arrange
+      var fixture = new AutoFixture.Fixture();
+
+      EstablishmentResponse establishment = new()
+      {
+         EstablishmentName = fixture.Create<string>(),
+         Urn = Guid.NewGuid().ToString(),
+         ViewAcademyConversion = new() { Pfi = "some-text" },
+         LocalAuthorityName = fixture.Create<string>(),
+         Gor = new EstablishmentResponse.Region() { Name = fixture.Create<string>() }
+      };
+
+      TrustDetail trust = new()
+      {
+         GiasData = new()
+         {
+            Ukprn = fixture.Create<string>(),
+            GroupId = fixture.Create<string>(),
+            GroupName = fixture.Create<string>(),
+            GroupType = fixture.Create<string>(),
+            CompaniesHouseNumber = fixture.Create<int>()
+         }
+      };
+
+      // Act
+      var result = CreateSponsoredProjectMapper.MapToDto(establishment, trust);
+
+      // Assert
+      result.School.PartOfPfiScheme.Should().BeTrue();
+      result.School.Region.Should().BeEquivalentTo(establishment.Gor.Name);
+      result.Trust.Should().NotBeNull().And.BeEquivalentTo(trust, cfg => cfg.ExcludingMissingMembers());
+      result.School.Should().NotBeNull().And.BeEquivalentTo(establishment, cfg => cfg.ExcludingMissingMembers());
+      
+      
+   }
+
+   [Theory]
+   [InlineData(default)]
+   [InlineData("")]
+   [InlineData("No")]
+   [InlineData("NO")]
+   [InlineData("no")]
+   [InlineData("nO")]
+   public void Should_Map_Establishment_Without_PfiScheme_And_Trust_Into_Dto_CreateSponsoredProject(string pfiScheme)
+   {
+      // Arrange
+      var fixture = new AutoFixture.Fixture();
+
+      EstablishmentResponse establishment = new()
+      {
+         EstablishmentName = fixture.Create<string>(),
+         Urn = Guid.NewGuid().ToString(),
+         ViewAcademyConversion = new() { Pfi = pfiScheme },
+         LocalAuthorityName = fixture.Create<string>(),
+         Gor = new EstablishmentResponse.Region() { Name = fixture.Create<string>() }
+      };
+
+      TrustDetail trust = new()
+      {
+         GiasData = new()
+         {
+            Ukprn = fixture.Create<string>(),
+            GroupId = fixture.Create<string>(),
+            GroupName = fixture.Create<string>(),
+            GroupType = fixture.Create<string>(),
+            CompaniesHouseNumber = fixture.Create<int>()
+         }
+      };
+
+      // Act
+      var result = CreateSponsoredProjectMapper.MapToDto(establishment, trust);
+
+      // Assert
+      using (var scope = new AssertionScope())
+      {
+         scope.AddReportable("pfiScheme", $"Using PFI Scheme value: {pfiScheme ?? "null"}");
+         result.School.PartOfPfiScheme.Should().BeFalse();
+         result.School.Region.Should().BeEquivalentTo(establishment.Gor.Name);
+         result.Trust.Should().NotBeNull().And.BeEquivalentTo(trust, cfg => cfg.ExcludingMissingMembers());
+         result.School.Should().NotBeNull().And.BeEquivalentTo(establishment, cfg => cfg.ExcludingMissingMembers());
+      }
+   }
+}

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Mappings/CreateSponsoredProjectMapper.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Mappings/CreateSponsoredProjectMapper.cs
@@ -1,0 +1,28 @@
+﻿using Dfe.PrepareConversions.Data.Models.Establishment;
+using Dfe.PrepareConversions.Data.Models.SponsoredProject;
+using Dfe.PrepareConversions.Data.Models.Trust;
+using System;
+
+namespace Dfe.PrepareConversions.Mappings;
+
+public class CreateSponsoredProjectMapper
+{
+   public static CreateSponsoredProject MapToDto(EstablishmentResponse establishment, TrustDetail trust)
+   {
+      var partOfPfiScheme = !string.IsNullOrWhiteSpace(establishment.ViewAcademyConversion?.Pfi)
+                            && establishment.ViewAcademyConversion?.Pfi.Equals("No", StringComparison.InvariantCultureIgnoreCase) == false;
+      
+      SponsoredProjectSchool createSchool = new(
+         establishment.EstablishmentName,
+         establishment.Urn,
+         partOfPfiScheme,
+         establishment.LocalAuthorityName,
+         establishment.Gor.Name);
+         
+      SponsoredProjectTrust createTrust = new(
+         trust.GiasData.GroupName,
+         trust.GiasData.GroupId);
+
+      return new CreateSponsoredProject(createSchool, createTrust);
+   }
+}

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Mappings/CreateSponsoredProjectMapper.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Mappings/CreateSponsoredProjectMapper.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Dfe.PrepareConversions.Mappings;
 
-public class CreateSponsoredProjectMapper
+public static class CreateSponsoredProjectMapper
 {
    public static CreateSponsoredProject MapToDto(EstablishmentResponse establishment, TrustDetail trust)
    {

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/SponsoredProject/Summary.cshtml.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/SponsoredProject/Summary.cshtml.cs
@@ -3,6 +3,7 @@ using Dfe.PrepareConversions.Data.Models.SponsoredProject;
 using Dfe.PrepareConversions.Data.Models.Trust;
 using Dfe.PrepareConversions.Data.Services;
 using Dfe.PrepareConversions.Data.Services.Interfaces;
+using Dfe.PrepareConversions.Mappings;
 using Dfe.PrepareConversions.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -43,22 +44,8 @@ public class SummaryModel : PageModel
       EstablishmentResponse establishment = await _getEstablishment.GetEstablishmentByUrn(urn);
       TrustDetail trust = await _trustRepository.GetTrustByUkprn(ukprn);
 
-      await _academyConversionProjectRepository.CreateSponsoredProject(MapToDto(establishment, trust));
+      await _academyConversionProjectRepository.CreateSponsoredProject(CreateSponsoredProjectMapper.MapToDto(establishment, trust));
 
       return RedirectToPage(Links.ProjectList.Index.Page);
-   }
-
-   private static CreateSponsoredProject MapToDto(EstablishmentResponse establishment, TrustDetail trust)
-   {
-      SponsoredProjectSchool createSchool = new(
-         establishment.EstablishmentName,
-         establishment.Urn,
-         establishment.ViewAcademyConversion?.Pfi != null && establishment.ViewAcademyConversion?.Pfi != "No");
-
-      SponsoredProjectTrust createTrust = new(
-         trust.GiasData.GroupName,
-         trust.GiasData.GroupId);
-
-      return new CreateSponsoredProject(createSchool, createTrust);
    }
 }

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,7 +1,8 @@
 ## NEXT
 * The term 'Involuntary Conversion' has been replaced with 'Sponsored Conversion'. This includes all Api endpoints. Note this requires a new release of the academies api with corresponding changes.
-
 * User Story 120665 : Updated PreviewProjectTemplate to hide `Legal requirements` and `rationale-for-project` when project is an involuntary conversion
+* User Story 129594 : The Local Authority and Region for a school is now passed up to the Academisation Api during involuntary project creation. This avoids the delay in populating the two values within the Academisation Api as they're already known during the conversion process.
+* User Story 129560 : Hides the row for Local Authority on the project list if the value is null.
 
 ---
 ## 1.1.1


### PR DESCRIPTION
Added local authority and region to the model sent from conversions when creating an involuntary conversion.
This will store the two values in the database immediately, and if not null then the background enrichment task in the academisation api will skip over them.