### PR TITLE
Deploy StatusCake SSL Checks for public endpoints

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -43,7 +43,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
 
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.76.0"
-  constraints = ">= 3.59.0"
+  constraints = ">= 3.52.0, >= 3.59.0, >= 3.76.0"
   hashes = [
     "h1:6NviPteLixeP1vrK42IcoV+tX1/tjisFmXUQd0gashc=",
     "h1:IDR5SgBUn5Bcaed9tE50c2o6j0KggbjN6IVwpBOjRPo=",
@@ -56,6 +56,18 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "h1:eArCWwNEShXmVWS08Ocd3d8ptsjbAaMECifkIBacpyw=",
     "h1:mdhZzFJ1Cnr5kr9Ievvg9eRTBw9So92fR49axnfzDTk=",
     "h1:xhmXxcAN5+n3GEY7dUWPrGQRmrEqOGpibQrSZ3ShrC4=",
+    "zh:33c6b1559b012d03befeb8ee9cf5b88c31acd64983dd4f727a49a436008b5577",
+    "zh:36d3cfa7cf2079a102ffce05da2de41ecf263310544990471c19ee01b135ccf3",
+    "zh:4481cda6a541116a756e9b206336aac7142ad1a063abcb592d2e0767256e436f",
+    "zh:4a4692b35517989c8eb6c52bb5435dfc342412620971a4a9c33e55e782559a4b",
+    "zh:52f3557d1bb156a7b4dcede631b326180caf091e25ff3976935ca40cdb8fac02",
+    "zh:7e4ba6d55d1d3e40379a746cb8ecaf9562b8831e62380fe5212b845702b36e6b",
+    "zh:8155f211b8a3af57d5ec9be9c775007a63cee587df8dd5e264cb4c70e9e2bb36",
+    "zh:a04c9763aef2e5e7b33f0b7da8af2d9e6910560425b6bb6065e4655ba278a047",
+    "zh:ab2a335765de282db3e6f29bd036d7a1404f7df4358ffa42a72163ee0cb48ba4",
+    "zh:b5cf262592d7ed3960d5e9d0c04f99a2e055cc918fe5e5e509a4f777a5001605",
+    "zh:bd8e096ed5062d97c49d19fc3b826119ede1c14173e7d6081af3bec0589f2080",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
 
@@ -77,5 +89,28 @@ provider "registry.terraform.io/hashicorp/null" {
     "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
     "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
     "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
+  ]
+}
+
+provider "registry.terraform.io/statuscakedev/statuscake" {
+  version     = "2.2.1"
+  constraints = ">= 2.1.0"
+  hashes = [
+    "h1:v9Zsszr6aXmjl0Zf6XfN+qOlIo+fJJL7iV1YLXuF/78=",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:443c840fd4ea0c7e8a45197c4823e7b122f087c7fac4f6ea96e9df1c499b9a39",
+    "zh:5c4a0f20dc321d45ba24207db0d21509a99a0531e150d989bf81c77ff3492ad1",
+    "zh:631e1bcab1703d6b722aeed3b709815575655b6bd28fca6ed48af64ee9205949",
+    "zh:6670e7dd4ac0a7e1ebb7370ad18d4a6d26a991602a138ba536538aa3b8a1cbc7",
+    "zh:6fa0b4200f08e088e382221095b75614e2a710e0185d28282a467a64fea84e3e",
+    "zh:8acff0f15c098f94643f0ecf7d3302f266869a53d97f7f647c8429d2b94f7ec1",
+    "zh:9007669557420a006ccbe7d03b1fb447a7a2770bde0db15909e0df63a89b936d",
+    "zh:93f0a45edbd4b851edca0ab49329a1de69261c26ac981c2aec985045bd60cf46",
+    "zh:99084f140c2be88b2554853fb5382f753e6809dadaa97b289f7cc92259c0d4d9",
+    "zh:d046b0d8b9fc512b3b483731f17edd8ee221f1dcaec649a8b8dcdde5400a90c4",
+    "zh:d0c966677d7a073d21605b351f2b3a83174901bcb6f25d4b4eb5b7822dac2d05",
+    "zh:dbd5ebfa764c0b58e764721704524c4f7028e70c8cb0b22efe494d588bf65cc0",
+    "zh:e492bdc2ddd32fe73532566affd6a9a22c0b75c042583d5450881f6c523441f8",
+    "zh:ee8f95766dbc1e1d2c41c6c837582af16b3e7ed5698c23471f1376011c7fa1a7",
   ]
 }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -125,8 +125,8 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.1 |
-| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 1.6.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.76.0 |
+| <a name="requirement_statuscake"></a> [statuscake](#requirement\_statuscake) | >= 2.1.0 |
 
 ## Providers
 
@@ -138,6 +138,7 @@ No providers.
 |------|--------|---------|
 | <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v1.1.0 |
 | <a name="module_azurerm_key_vault"></a> [azurerm\_key\_vault](#module\_azurerm\_key\_vault) | github.com/DFE-Digital/terraform-azurerm-key-vault-tfvars | v0.2.2 |
+| <a name="module_statuscake-tls-monitor"></a> [statuscake-tls-monitor](#module\_statuscake-tls-monitor) | github.com/dfe-digital/terraform-statuscake-tls-monitor | v0.1.2 |
 
 ## Resources
 
@@ -183,6 +184,11 @@ No resources.
 | <a name="input_monitor_email_receivers"></a> [monitor\_email\_receivers](#input\_monitor\_email\_receivers) | A list of email addresses that should be notified by monitoring alerts | `list(string)` | n/a | yes |
 | <a name="input_monitor_endpoint_healthcheck"></a> [monitor\_endpoint\_healthcheck](#input\_monitor\_endpoint\_healthcheck) | Specify a route that should be monitored for a 200 OK status | `string` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
+| <a name="input_statuscake_api_token"></a> [statuscake\_api\_token](#input\_statuscake\_api\_token) | API token for StatusCake | `string` | `"00000000000000000000000000000"` | no |
+| <a name="input_statuscake_contact_group_email_addresses"></a> [statuscake\_contact\_group\_email\_addresses](#input\_statuscake\_contact\_group\_email\_addresses) | List of email address that should receive notifications from StatusCake | `list(string)` | `[]` | no |
+| <a name="input_statuscake_contact_group_integrations"></a> [statuscake\_contact\_group\_integrations](#input\_statuscake\_contact\_group\_integrations) | List of Integration IDs to connect to your Contact Group | `list(string)` | `[]` | no |
+| <a name="input_statuscake_contact_group_name"></a> [statuscake\_contact\_group\_name](#input\_statuscake\_contact\_group\_name) | Name of the contact group in StatusCake | `string` | `""` | no |
+| <a name="input_statuscake_monitored_resource_addresses"></a> [statuscake\_monitored\_resource\_addresses](#input\_statuscake\_monitored\_resource\_addresses) | The URLs to perform TLS checks on | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | n/a | yes |
 | <a name="input_tfvars_filename"></a> [tfvars\_filename](#input\_tfvars\_filename) | tfvars filename. This file is uploaded and stored encrupted within Key Vault, to ensure that the latest tfvars are stored in a shared place. | `string` | n/a | yes |
 | <a name="input_virtual_network_address_space"></a> [virtual\_network\_address\_space](#input\_virtual\_network\_address\_space) | Virtual network address space CIDR | `string` | n/a | yes |

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -38,4 +38,8 @@ locals {
   existing_logic_app_workflow                  = var.existing_logic_app_workflow
   existing_network_watcher_name                = var.existing_network_watcher_name
   existing_network_watcher_resource_group_name = var.existing_network_watcher_resource_group_name
+  statuscake_monitored_resource_addresses      = var.statuscake_monitored_resource_addresses
+  statuscake_contact_group_name                = var.statuscake_contact_group_name
+  statuscake_contact_group_integrations        = var.statuscake_contact_group_integrations
+  statuscake_contact_group_email_addresses     = var.statuscake_contact_group_email_addresses
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -3,4 +3,6 @@ provider "azurerm" {
   skip_provider_registration = true
 }
 
-provider "azapi" {}
+provider "statuscake" {
+  api_token = var.statuscake_api_token
+}

--- a/terraform/statuscake-tls-monitor.tf
+++ b/terraform/statuscake-tls-monitor.tf
@@ -1,0 +1,11 @@
+module "statuscake-tls-monitor" {
+  source = "github.com/dfe-digital/terraform-statuscake-tls-monitor?ref=v0.1.2"
+
+  statuscake_monitored_resource_addresses = local.statuscake_monitored_resource_addresses
+  statuscake_alert_at = [ # days to alert on
+    14, 7, 3
+  ]
+  statuscake_contact_group_name            = local.statuscake_contact_group_name
+  statuscake_contact_group_integrations    = local.statuscake_contact_group_integrations
+  statuscake_contact_group_email_addresses = local.statuscake_contact_group_email_addresses
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -218,3 +218,34 @@ variable "dns_txt_records" {
     })
   )
 }
+
+variable "statuscake_api_token" {
+  description = "API token for StatusCake"
+  type        = string
+  sensitive   = true
+  default     = "00000000000000000000000000000"
+}
+
+variable "statuscake_contact_group_name" {
+  description = "Name of the contact group in StatusCake"
+  type        = string
+  default     = ""
+}
+
+variable "statuscake_contact_group_integrations" {
+  description = "List of Integration IDs to connect to your Contact Group"
+  type        = list(string)
+  default     = []
+}
+
+variable "statuscake_monitored_resource_addresses" {
+  description = "The URLs to perform TLS checks on"
+  type        = list(string)
+  default     = []
+}
+
+variable "statuscake_contact_group_email_addresses" {
+  description = "List of email address that should receive notifications from StatusCake"
+  type        = list(string)
+  default     = []
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -5,9 +5,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.76.0"
     }
-    azapi = {
-      source  = "Azure/azapi"
-      version = ">= 1.6.0"
+    statuscake = {
+      source  = "StatusCakeDev/statuscake"
+      version = ">= 2.1.0"
     }
   }
 }


### PR DESCRIPTION
**What is the change?**
Deploy 3 SSL Checks and a Contact Group on StatusCake

**Why do we need the change?**
Azure Monitor is not very reliable for TLS validity checks so we're using StatusCake instead.
We can deploy a SSL Certificate validity check that polls the dev, test, and prod health check endpoints once every 24H and notify us via Slack (integration)/Email at 14, 7 and 3 days before expiry

**What is the impact?**
None
