### PR TITLE
Update conversionDetails.js

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/pages/conversionDetails.js
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/pages/conversionDetails.js
@@ -34,7 +34,7 @@ export default class ConversionDetails extends BasePage {
         advisoryBoardDateInput: 'head-teacher-board-date',
         proposedOpeningLink: '[data-test="change-proposed-academy-opening-date"]',
         proposedOpeningValue: '[id="proposed-academy-opening-date"]',
-        proposedOpeningRadioButton: (month, year) => `input[data-cy="select-radio-01/${month}/${year} 00:00:00"]`,
+        proposedOpeningRadioButton: (month, year) => `input[data-cy="select-radio-${month}/01/${year} 00:00:00"]`,
         previousAdvisoryBoardLink: '[data-test="change-previous-advisory-board"]',
         previousAdvisoryBoardValue: '[id="previous-advisory-board"]',
         previousAdvisoryBoardDateInput: 'previous-head-teacher-board-date',


### PR DESCRIPTION
**Description:**

This pull request addresses an issue related to a Cypress test file. The target element selection in the test was using an outdated pattern, and it has been updated to match the new pattern as per the recent code changes.

**Changes:**
- Updated the `proposedOpeningRadioButton` function in the Cypress test file.
- Replaced the old selector pattern `"select-radio-01"` with the new pattern `"select-radio-${month}/01/${year}"`.

**Before:**
```javascript
proposedOpeningRadioButton: (month, year) => `input[data-cy="select-radio-01/${month}/${year} 00:00:00"]`,
```

**After:**
```javascript
cy.get(`input[data-cy="select-radio-${month}/01/${year} 00:00:00"]`);
```

This change ensures that the Cypress test targets the correct element with the updated selector pattern.