### PR TITLE
Modify build and push workflow for ACR import

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -27,6 +27,7 @@ jobs:
       branch: ${{ steps.var.outputs.branch }}
       release: ${{ steps.var.outputs.release }}
       checked-out-sha: ${{ steps.var.outputs.checked-out-sha }}
+      github_repository_lc: ${{ steps.var.outputs.github_repository_lc }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -40,13 +41,15 @@ jobs:
           ENVIRONMENT=${INPUT:-"dev"}
           RELEASE=${ENVIRONMENT,,}-`date +%Y-%m-%d`.${{ github.run_number }}
           CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
+          GITHUB_REPOSITORY=${{ github.repository }}
           echo "environment=${ENVIRONMENT,,}" >> $GITHUB_OUTPUT
           echo "branch=$GIT_BRANCH" >> $GITHUB_OUTPUT
           echo "release=${RELEASE}" >> $GITHUB_OUTPUT
           echo "checked-out-sha=${CHECKED_OUT_SHA}" >> $GITHUB_OUTPUT
+          echo "github_repository_lc=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
 
   build-and-push-image:
-    name: Build and push to ACR
+    name: Build and push to GHCR
     needs: set-env
     runs-on: ubuntu-22.04
     environment: ${{ needs.set-env.outputs.environment }}
@@ -55,12 +58,12 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Azure Container Registry login
+      - name: GitHub Container Registry login
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.AZURE_ACR_CLIENTID }}
-          password: ${{ secrets.AZURE_ACR_SECRET }}
-          registry: ${{ secrets.AZURE_ACR_URL }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
 
       - name: Build and push docker image
         uses: docker/build-push-action@v5
@@ -68,12 +71,12 @@ jobs:
           context: .
           file: Dockerfile
           build-args: COMMIT_SHA=${{ needs.set-env.outputs.checked-out-sha }}
-          secrets: github_token=${{ secrets.GITHUB_TOKEN }}          
+          secrets: github_token=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.branch }}
-            ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.release }}
-            ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:sha-${{ needs.set-env.outputs.checked-out-sha }}
-            ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:latest
+            ghcr.io/${{ needs.set-env.outputs.github_repository_lc }}:${{ needs.set-env.outputs.branch }}
+            ghcr.io/${{ needs.set-env.outputs.github_repository_lc }}:${{ needs.set-env.outputs.release }}
+            ghcr.io/${{ needs.set-env.outputs.github_repository_lc }}:sha-${{ needs.set-env.outputs.checked-out-sha }}
+            ghcr.io/${{ needs.set-env.outputs.github_repository_lc }}:latest
           push: true
 
   create-tag:
@@ -109,9 +112,43 @@ jobs:
               core.setFailed(error.message);
             }
 
+  acr-import:
+    name: Import images to ${{ needs.set-env.outputs.environment }} ACR
+    needs: [ build-and-push-image, set-env ]
+    runs-on: ubuntu-22.04
+    environment: ${{ needs.set-env.outputs.environment }}
+    steps:
+      - name: Azure login with ACR credentials
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.ACR_CREDENTIALS }}
+
+      - name: Run ACR Import
+        uses: azure/cli@v2
+        with:
+          azcliversion: 2.45.0
+          inlineScript: |
+            TAGS=(
+              ${{ needs.set-env.outputs.branch }}
+              ${{ needs.set-env.outputs.release }}
+              sha-${{ needs.set-env.outputs.checked-out-sha }}
+              latest
+            )
+            az config set extension.use_dynamic_install=yes_without_prompt
+            for tag in "${TAGS[@]}"
+            do
+              az acr import \
+                --name ${{ secrets.ACR_NAME }} \
+                --source "ghcr.io/${{ needs.set-env.outputs.github_repository_lc }}:$tag" \
+                --image "${{ env.DOCKER_IMAGE }}:$tag" \
+                --username ${{ github.actor }} \
+                --password ${{ secrets.GITHUB_TOKEN }} \
+                --force
+            done
+
   deploy-image:
     name: Deploy to ${{ needs.set-env.outputs.environment }} (${{ needs.set-env.outputs.release }})
-    needs: [ build-and-push-image, set-env ]
+    needs: [ build-and-push-image, set-env, acr-import ]
     runs-on: ubuntu-22.04
     environment: ${{ needs.set-env.outputs.environment }}
     steps:
@@ -121,8 +158,7 @@ jobs:
           creds: ${{ secrets.AZURE_ACA_CREDENTIALS }}
 
       - name: Update Azure Container Apps Revision
-        uses: azure/CLI@v2
-        id: azure
+        uses: azure/cli@v2
         with:
           azcliversion: 2.45.0
           inlineScript: |
@@ -130,7 +166,7 @@ jobs:
             az containerapp update \
               --name ${{ secrets.AZURE_ACA_NAME }} \
               --resource-group ${{ secrets.AZURE_ACA_RESOURCE_GROUP }} \
-              --image ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.release }} \
+              --image ${{ secrets.ACR_NAME }}.azurecr.io/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.release }} \
               --output none
 
   cypress-tests:
@@ -178,7 +214,7 @@ jobs:
         if: always()
         run: |
             mkdir mochareports
-            npm run generate:html:report    
+            npm run generate:html:report
 
       - name: Upload report
         if: always()
@@ -186,11 +222,9 @@ jobs:
         with:
           name: reports-${{ needs.set-env.outputs.environment }}
           path: Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/mochareports
-    
+
       - name: Report results
         if: always()
         run: npm run cy:notify -- --custom-text="Environment ${{ needs.set-env.outputs.environment }}, See more information https://github.com/DFE-Digital/prepare-academy-conversions/actions/runs/${{github.run_id}}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-    


### PR DESCRIPTION
* This modifies the build and push workflow, so that the image is pushed to GitHub Container Registry, and then Imported from the ACR. This allows the ACR to be confiured as Private (No public access).