### PR TITLE
Add exclusion paths for build and test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,17 @@ name: Pull request checks
 on:
   push:
     branches: [ main ]
+    paths:
+    - 'Dfe.PrepareConversions.*'
+    - '!Dfe.PrepareConversions.Dfe.PrepareConversions.CypressTests'
+    - '*.csproj'
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened]
+    paths:
+    - 'Dfe.PrepareConversions.*'
+    - '!Dfe.PrepareConversions.Dfe.PrepareConversions.CypressTests'
+    - '*.csproj'
 
 env:
   JAVA_VERSION: '17'


### PR DESCRIPTION
Sets paths to restrict when to run build and test.

This is to reduce the amount of times that sonarcloud is ran and to free up github runners