### PR TITLE
Fix layout issues with shared templates

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Errors/Index.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Errors/Index.cshtml
@@ -5,18 +5,14 @@
 @{
     ViewData["Title"] = @Model.ErrorMessage;
 }
-<div class="govuk-width-container">
-   <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
-      <div class="govuk-grid-row">
-         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l" id="error-heading">@Model.ErrorMessage</h1>
-            <p class="govuk-body">
-               A fault has stopped us from doing what you asked. It might work next time if you try again.
-            </p>
-            <p class="govuk-body">
-               Email the Prepare conversions and transfers team at <a href="mailto:@Configuration["SupportEmail"]?subject=Prepare%20conversions%20and%20transfers:%20support%20query" class="govuk-link">@Configuration["SupportEmail"]</a> if this error continues.
-            </p>
-         </div>
-      </div>
-   </main>
+<div class="govuk-grid-row">
+   <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l" id="error-heading">@Model.ErrorMessage</h1>
+      <p class="govuk-body">
+         A fault has stopped us from doing what you asked. It might work next time if you try again.
+      </p>
+      <p class="govuk-body">
+         Email the Prepare conversions and transfers team at <a href="mailto:@Configuration["SupportEmail"]?subject=Prepare%20conversions%20and%20transfers:%20support%20query" class="govuk-link">@Configuration["SupportEmail"]</a> if this error continues.
+      </p>
+   </div>
 </div>

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/_Layout.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/_Layout.cshtml
@@ -148,7 +148,7 @@
     <footer class="govuk-footer " role="contentinfo">
         <div class="dfe-width-container">
             <div class="govuk-footer__navigation">
-                <div class="govuk-footer__section" data-cy="get-support-section">
+                <div class="govuk-footer__section govuk-grid-column-one-half" data-cy="get-support-section">
                     <h2 class="govuk-footer__heading govuk-heading-m">Get support</h2>
                     <ul class="govuk-footer__list govuk-footer__list--columns-1">
                         <li class="govuk-footer__list-item">
@@ -158,7 +158,7 @@
                             </a>
                     </ul>
                 </div>
-                <div class="govuk-footer__section">
+                <div class="govuk-footer__section govuk-grid-column-one-half">
                     <h2 class="govuk-footer__heading govuk-heading-m">Give feedback</h2>
                     <ul class="govuk-footer__list govuk-footer__list--columns-1">
                         <li class="govuk-footer__list-item">


### PR DESCRIPTION
The Error razor template had an extra `<main>` tag which was not only throwing out the UI layout, but also breaking accessibility and HTML semantics on the page.

I also added missing CSS classes onto the footer columns so that they correctly align within the grid layout
