### PR TITLE
Cypress refactor

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/e2e/Core-journeys/application_Form_tests.cy.js
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/e2e/Core-journeys/application_Form_tests.cy.js
@@ -1,0 +1,95 @@
+import '../../support/commands';
+import projectTaskList from "../../pages/projectTaskList";
+const applicationFormTaskList = require('../../pages/applicationFormTaskList');
+
+describe('Test Application Form for Voluntary and Form a MAT', { tags: ['@dev', '@stage'] }, () => {
+
+    beforeEach(() => {
+        projectTaskList.getHomePage();
+    });
+
+   it('Should filter and select the project, then verify details of Voluntary', () => {
+
+    // Step 1: Filter search
+    applicationFormTaskList.filterSearch('Fahads Cypress Trust');
+
+    // Step 2: Verify the title and route
+    applicationFormTaskList.checkTitle('Fahads Cypress Trust');
+    applicationFormTaskList.checkRoute('Voluntary conversion');
+
+    // Step 3: Select the first search result
+     applicationFormTaskList.selectFirstSearchResult();
+
+    // Step 4: Click on school application form
+    applicationFormTaskList.clickSchoolApplicationForm();
+
+    //Step 4.1: Check URL contains to contain school-application-form
+    applicationFormTaskList.checkUrlContainsSchoolApplicationForm();
+
+    //Step 4.2: Check the route 
+    applicationFormTaskList.checkRouteAppForm('Voluntary conversion');
+
+    // Step 5: Check the table contents
+    const expectedContents = [
+      'Overview',
+      'About the conversion',
+      'Further information',
+      'Finances',
+      'Future pupil numbers',
+      'Land and buildings',
+      'Pre-opening support grant',
+      'Consultation',
+      'Declaration'
+    ];
+    applicationFormTaskList.checkTableContents(expectedContents);
+
+    // Step 6: Check Overview1_value
+    applicationFormTaskList.checkElementText('[test-id="Overview1_value"]', 'PLYMOUTH CAST with Plymstock School');
+
+    // Step 7: Check Application reference
+    applicationFormTaskList.checkElementText('[test-id="Overview2"]', 'A2B_124378');
+  });
+  
+  it('Should filter and select the project, then verify details of a Form a MAT project', () => {
+
+    // Step 1: Filter search
+    applicationFormTaskList.clickFormAMAT();
+    applicationFormTaskList.filterSearch('Fahads Cypress Trust');
+
+
+    // Step 2: Select the first search result
+     applicationFormTaskList.selectFirstSearchResultFormAMAT();
+
+    //Step 2.1: Check URL contains to contain school-application-form
+    applicationFormTaskList.checkUrlContainsschoolsinthismat();
+//step 2.2: Click on the first project
+    applicationFormTaskList.selectFirstProjectFormAMAT();
+    //Step 2.3: Check the route 
+    applicationFormTaskList.checkRouteAppForm('Form a MAT Voluntary conversion');
+    // Step 3: Click on school application form
+    applicationFormTaskList.clickSchoolApplicationFormForFormAMAT();
+
+    // Step 4: Check the table contents
+    
+    const expectedContents = [
+      'Overview',
+      'Trust information',
+      'Key people within the trust',
+      'About the conversion',
+      'Further information',
+      'Finances',
+      'Future pupil numbers',
+      'Land and buildings',
+      'Pre-opening support grant',
+      'Consultation',
+      'Declaration'
+    ];
+    applicationFormTaskList.checkTableContents(expectedContents);
+
+    // Step 5: Check Overview1_value
+    applicationFormTaskList.checkElementText('[test-id="Overview1_value"]', 'Plymouth with Fahads Cypress Trust');
+
+    // Step 6: Check Application reference
+    applicationFormTaskList.checkElementText('[test-id="Overview2"]', 'A2B_124335');
+  });
+});

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/pages/applicationFormTaskList.js
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/pages/applicationFormTaskList.js
@@ -1,0 +1,85 @@
+class ApplicationFormTaskList {
+    // Method to interact with the filter search input
+    filterSearch(title) {
+      cy.get('[data-cy="select-projectlist-filter-title"]').type(title);
+      cy.get('[data-cy="select-projectlist-filter-apply"]').click();
+    }
+  
+    // Method to select the first search result
+    selectFirstSearchResult() {
+        cy.get('#school-name-0').click();
+    }
+
+      // Method to select the first search result for Form a MAT
+      selectFirstSearchResultFormAMAT() {
+        cy.get('#trust-name-0').click();
+    }
+  
+    // Method to check the route
+    checkRoute(expectedRoute) {
+        cy.get('#type-and-route-0 > span').should('contain', expectedRoute);
+    }
+  
+    // Method to check the page title
+    checkTitle(title) {
+        cy.get('#school-name-0').should('contain', title);
+    }
+
+    //method to click on the first form a mat project 
+    selectFirstProjectFormAMAT() {  
+        cy.get('#school-name-0').click();
+    }
+  
+    // Method to click on school application form
+    clickSchoolApplicationForm() {
+
+        cy.get('[data-cy="school_application_form"]').click();
+    }
+  // Method to click on school application form for Form a MAT page
+    clickSchoolApplicationFormForFormAMAT() {
+
+        cy.get('[data-cy="school_application_form_formamat"]').click();
+    }
+      // Method to click on school application form First project
+      clickSchoolApplicationFormFirstProjet() {
+
+        cy.get('#school-name-0').click();
+    }
+
+  // Method to check the url contains school-application-form
+    checkUrlContainsSchoolApplicationForm() {
+  cy.url().should('contain', 'school-application-form');
+    }
+
+     // Method to check the url contains schools-in-this-mat
+     checkUrlContainsschoolsinthismat() {
+        cy.url().should('contain', 'schools-in-this-mat');
+          }
+
+      // Method to check the route in Application Form page
+      checkRouteAppForm(expectedRouteAppRoute) {
+        
+    cy.get('[data-cy="route"]').should('contain', expectedRouteAppRoute);
+  
+    }
+    // Method to check the contents of the table
+  checkTableContents(expectedContents) {
+    cy.get('[data-cy="content-Table"]').within(() => {
+      expectedContents.forEach((content, index) => {
+        cy.get('[data-cy="contents_list_items"]').eq(index).should('contain', content);
+      });
+    });
+  }
+
+  // Method to check specific elements for expected text
+  checkElementText(selector, expectedText) {
+    cy.get(selector).should('contain', expectedText);
+  }
+
+  clickFormAMAT() { 
+    cy.get('[data-cy="formAMatLink"]').click();
+  }
+}
+  
+  module.exports = new ApplicationFormTaskList();
+  

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/pages/projectTaskList.js
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/pages/projectTaskList.js
@@ -96,6 +96,10 @@ export default class ProjectTaskList extends BasePage {
         cy.checkPath(this.path)
         return cy.get(this.selectors.riskAndIssuesStatus)
     }
+    
+    static getHomePage() {
+        cy.visit(`${Cypress.env('url')}`)
+    }
 
     static selectLA() {
         cy.checkPath(this.path)

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/ApplicationForm/Index.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/ApplicationForm/Index.cshtml
@@ -17,12 +17,12 @@
 </p>
 <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">School application form</h2>
 
-<nav class="gem-c-contents-list" aria-label="Pages in this guide" role="navigation" data-module="gem-track-click">
+<nav class="gem-c-contents-list" aria-label="Pages in this guide" role="navigation" data-module="gem-track-click" data-cy="content-Table">
    <h2 class="gem-c-contents-list__title">Contents</h2>
    <ol class="gem-c-contents-list__list">
       @foreach (BaseFormSection formSection in Model.Sections)
       {
-         <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+         <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed" data-cy="contents_list_items">
             <a id="@Model.GenerateId(formSection.Heading)_link" class="gem-c-contents-list__link govuk-link" href="#@Model.GenerateId(formSection.Heading)">@formSection.Heading</a>
          </li>
       }

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/FormAMat/Index.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/FormAMat/Index.cshtml
@@ -17,12 +17,12 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h2 class="govuk-heading-l govuk-!-margin-bottom govuk-!-font-size-36">School application form</h2>
-            <nav class="gem-c-contents-list" aria-label="Pages in this guide" role="navigation" data-module="gem-track-click">
+		<nav class="gem-c-contents-list" aria-label="Pages in this guide" role="navigation" data-module="gem-track-click" data-cy="content-Table">
                 <h2 class="gem-c-contents-list__title">Contents</h2>
                 <ol class="gem-c-contents-list__list">
                 @foreach (BaseFormSection formSection in Model.Sections)
                 {
-                    <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+					<li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed" data-cy="contents_list_items">
                         <a id="@Model.GenerateId(formSection.Heading)_link" class="gem-c-contents-list__link govuk-link" href="#@Model.GenerateId(formSection.Heading)">@formSection.Heading</a>
                     </li>
                 }

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/_Layout.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/_Layout.cshtml
@@ -111,7 +111,7 @@
                             </svg>
                         </a>
                     </li>
-                    <li class="dfe-header__navigation-item @(isFormAMatPage ? "dfe-header__navigation-item--current": "")">
+					<li data-cy ="formAMatLink" class="dfe-header__navigation-item @(isFormAMatPage ? "dfe-header__navigation-item--current" : "")">
                         <a asp-page="@Links.ProjectList.FormAMat.Page" class="dfe-header__navigation-link">
                             Form a MAT
                             <svg class="dfe-icon dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/_ProjectHeader.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/_ProjectHeader.cshtml
@@ -5,7 +5,7 @@
       <h1 class="govuk-heading-xl govuk-!-margin-bottom-2" data-cy="select-heading">
          @Model.SchoolName
       </h1>
-        <p class="govuk-body govuk-!-margin-bottom-1">
+        <p class="govuk-body govuk-!-margin-bottom-1" data-cy="route">
             Route: @Model.AcademyTypeAndRoute.RouteDescription(@Model.IsFormAMat)
         </p>
       <p class="govuk-body govuk-!-margin-bottom-5">

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/_SubMenu.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/_SubMenu.cshtml
@@ -14,7 +14,7 @@
         </li>
 
         <li if="@Model.IsVoluntary && !Model.IsExternalSchoolApplication && !Model.IsFormAMat" class="moj-sub-navigation__item">
-            <sub-menu-link class="moj-sub-navigation__link"
+            <sub-menu-link class="moj-sub-navigation__link" data-cy= "school_application_form"
                            asp-page="@Links.ApplicationForm.Index.Page"
                            asp-route-id="@id">
                 School application form
@@ -29,7 +29,7 @@
             </sub-menu-link>
         </li>
 
-        <li if="@Model.IsFormAMat && !Model.IsExternalSchoolApplication" class="moj-sub-navigation__item">
+        <li if="@Model.IsFormAMat && !Model.IsExternalSchoolApplication" class="moj-sub-navigation__item" data-cy="school_application_form_formamat">
             <sub-menu-link class="moj-sub-navigation__link"
                            asp-page="@Links.FormAMat.Index.Page"
                            asp-route-id="@id">


### PR DESCRIPTION
**Title:** Enhanced Cypress Test Suite for "Form a MAT" and "Voluntary Conversion" Projects in School Application Form

**Description:**
Our Cypress test suite has been significantly enhanced to incorporate additional checks and functionalities for the "Form a MAT" and "Voluntary Conversion" projects. The updates include:

1. Implementation of filtering and selection logic based on "Fahads Cypress Trust" for project identification for both Conversion and Form A MAT projects.
2. Validation of page titles and routes.
3. Interaction with the school application form and validation of its table of contents for both Conversion and Form A MAT projects.
4. Integration of methods to verify URLs containing "school-application-form" for Voluntary Conversion and "schools-in-this-mat" for Form a MAT.
5. Addition of specialised methods tailored for interacting with "Form a MAT" projects.
6. Inclusion of assertions to ensure specific elements display expected text, such as "Overview1_value" (Application to join: ) and "ApplicationReference_value" (Application reference:).

**Assignees:**
- Fahad Darwish

**Tags:**
- Cypress
- End-to-End Testing
- "Form a MAT"
- "Voluntary Conversion"
- Quality Assurance

Kindly review the updates and proceed with merging the PR if everything aligns with expectations. Your cooperation is highly appreciated! 