### PR TITLE
Fix: Constrained width of container to match header

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/_Layout.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/_Layout.cshtml
@@ -76,7 +76,7 @@
 
     @if (!string.IsNullOrWhiteSpace(notificationBannerMessage))
     {
-        <div class="govuk-extra-width-container">
+        <div class="dfe-width-container">
             <section class="govuk-notification-banner govuk-!-margin-bottom-0" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
                 <div class="govuk-notification-banner__header">
                     <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">


### PR DESCRIPTION
The wrapper element had the wrong css class on it.

**Before:**
![Screenshot 2024-05-23 at 17 17 52](https://github.com/DFE-Digital/prepare-academy-conversions/assets/3853061/bf1c1598-3465-4695-87e6-ec96203e1840)

**After:**
![Screenshot 2024-05-23 at 17 18 01](https://github.com/DFE-Digital/prepare-academy-conversions/assets/3853061/3fd674b2-8147-4720-8ce6-70b697bbef10)
