### PR TITLE
Refactor workflows to use reusable Cypress workflow

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -89,58 +89,8 @@ jobs:
     name: Run Cypress Tests
     if: needs.set-env.outputs.environment == 'staging' || needs.set-env.outputs.environment == 'dev'
     needs: [ deploy-image, set-env ]
-    runs-on: ubuntu-22.04
-    environment: ${{ needs.set-env.outputs.environment }}
-    defaults:
-      run:
-        working-directory: Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Setup node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Npm install
-        run: npm install
-
-      - name: Run cypress (staging)
-        if: needs.set-env.outputs.environment == 'staging'
-        run: npm run cy:run -- --env url='${{ secrets.AZURE_ENDPOINT }}',grep='-dao',cypressTestSecret='${{ secrets.CYPRESS_TEST_SECRET }}, academisationApiUrl=${{secrets.CYPRESS_ACADEMISATION_API_URL}}, academisationApiKey=${{ secrets.CYPRESS_ACADEMISATION_API_KEY}}'
-        env:
-          db: ${{ secrets.DB_CONNECTION_STRING }}
-
-      - name: Run cypress (dev)
-        if: needs.set-env.outputs.environment == 'dev'
-        run: npm run cy:run -- --env url='${{ secrets.AZURE_ENDPOINT }}',cypressTestSecret='${{ secrets.CYPRESS_TEST_SECRET }}, academisationApiUrl=${{secrets.CYPRESS_ACADEMISATION_API_URL}}, academisationApiKey=${{ secrets.CYPRESS_ACADEMISATION_API_KEY}}'
-        env:
-          db: ${{ secrets.DB_CONNECTION_STRING }}
-
-      - name: Upload screenshots
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: screenshots-${{ needs.set-env.outputs.environment }}
-          path: Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/screenshots
-
-      - name: Generate report
-        if: always()
-        run: |
-            mkdir mochareports
-            npm run generate:html:report
-
-      - name: Upload report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: reports-${{ needs.set-env.outputs.environment }}
-          path: Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/mochareports
-
-      - name: Report results
-        if: always()
-        run: npm run cy:notify -- --custom-text="Environment ${{ needs.set-env.outputs.environment }}, See more information https://github.com/DFE-Digital/prepare-academy-conversions/actions/runs/${{github.run_id}}"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    runs-on: ubuntu-latest
+    uses: ./.github/workflows/cypress.yml
+    with:
+      environment: ${{ needs.set-env.outputs.environment }}
+    secrets: inherit

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -54,12 +54,13 @@ jobs:
         run: npm install
 
       - name: Run cypress (dev)
+        if: inputs.environment == 'dev'
         run: npm run cy:run -- --env url='${{ secrets.AZURE_ENDPOINT }}',cypressTestSecret='${{ secrets.CYPRESS_TEST_SECRET }}, academisationApiUrl=${{secrets.CYPRESS_ACADEMISATION_API_URL}}, academisationApiKey=${{ secrets.CYPRESS_ACADEMISATION_API_KEY}}'
         env:
           db: ${{ secrets.DB_CONNECTION_STRING }}
 
       - name: Run cypress (staging)
-        if: needs.set-env.outputs.environment == 'staging'
+        if: inputs.environment == 'staging'
         run: npm run cy:run -- --env url='${{ secrets.AZURE_ENDPOINT }}',grep='-dao',cypressTestSecret='${{ secrets.CYPRESS_TEST_SECRET }}, academisationApiUrl=${{secrets.CYPRESS_ACADEMISATION_API_URL}}, academisationApiKey=${{ secrets.CYPRESS_ACADEMISATION_API_KEY}}'
         env:
           db: ${{ secrets.DB_CONNECTION_STRING }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,7 +1,30 @@
-name: Run Cypress Accessibility checks
+name: Run Cypress tests
 
 on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+    secrets:
+      AZURE_ENDPOINT:
+        required: true
+      CYPRESS_TEST_SECRET:
+        required: true
+      CYPRESS_ACADEMISATION_API_URL:
+        required: true
+      CYPRESS_ACADEMISATION_API_KEY:
+        required: true
+      DB_CONNECTION_STRING:
+        required: true
+      SLACK_WEBHOOK_URL:
+        required: true
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to run tests against'
+        required: true
+        type: environment
 
 concurrency:
   group: ${{ github.workflow }}
@@ -13,7 +36,7 @@ jobs:
   cypress-tests:
     name: Run Cypress Tests
     runs-on: ubuntu-latest
-    environment: dev
+    environment: ${{ inputs.environment }}
     defaults:
       run:
         working-directory: Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests
@@ -32,6 +55,12 @@ jobs:
 
       - name: Run cypress (dev)
         run: npm run cy:run -- --env url='${{ secrets.AZURE_ENDPOINT }}',cypressTestSecret='${{ secrets.CYPRESS_TEST_SECRET }}, academisationApiUrl=${{secrets.CYPRESS_ACADEMISATION_API_URL}}, academisationApiKey=${{ secrets.CYPRESS_ACADEMISATION_API_KEY}}'
+        env:
+          db: ${{ secrets.DB_CONNECTION_STRING }}
+
+      - name: Run cypress (staging)
+        if: needs.set-env.outputs.environment == 'staging'
+        run: npm run cy:run -- --env url='${{ secrets.AZURE_ENDPOINT }}',grep='-dao',cypressTestSecret='${{ secrets.CYPRESS_TEST_SECRET }}, academisationApiUrl=${{secrets.CYPRESS_ACADEMISATION_API_URL}}, academisationApiKey=${{ secrets.CYPRESS_ACADEMISATION_API_KEY}}'
         env:
           db: ${{ secrets.DB_CONNECTION_STRING }}
 


### PR DESCRIPTION
Pulls out the Cypress tests into their own reusable workflow independent of the deploy workflow.

Cypress workflow can now either be triggered manually for dev/staging, or is called after a successful deployment.