### PR TITLE
Add Key Vault Data Protection to dotnet

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Dfe.PrepareConversions.csproj
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Dfe.PrepareConversions.csproj
@@ -38,7 +38,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="AngleSharp" Version="1.1.2" />
-	  <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.3" />
+	  <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.3.0" />
 	  <PackageReference Include="Azure.Identity" Version="1.12.1" />
 	  <PackageReference Include="Dfe.Academies.Contracts" Version="1.0.10" />
 	  <PackageReference Include="Dfe.Academisation.CorrelationIdMiddleware" Version="2.0.2" />

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Dfe.PrepareConversions.csproj
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Dfe.PrepareConversions.csproj
@@ -38,6 +38,8 @@
 
 	<ItemGroup>
 	  <PackageReference Include="AngleSharp" Version="1.1.2" />
+	  <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.3" />
+	  <PackageReference Include="Azure.Identity" Version="1.11.3" />
 	  <PackageReference Include="Dfe.Academies.Contracts" Version="1.0.10" />
 	  <PackageReference Include="Dfe.Academisation.CorrelationIdMiddleware" Version="2.0.2" />
 	  <PackageReference Include="Dfe.Academisation.ExtensionMethods" Version="2.0.0" />

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Dfe.PrepareConversions.csproj
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Dfe.PrepareConversions.csproj
@@ -39,7 +39,7 @@
 	<ItemGroup>
 	  <PackageReference Include="AngleSharp" Version="1.1.2" />
 	  <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.3" />
-	  <PackageReference Include="Azure.Identity" Version="1.11.3" />
+	  <PackageReference Include="Azure.Identity" Version="1.12.1" />
 	  <PackageReference Include="Dfe.Academies.Contracts" Version="1.0.10" />
 	  <PackageReference Include="Dfe.Academisation.CorrelationIdMiddleware" Version="2.0.2" />
 	  <PackageReference Include="Dfe.Academisation.ExtensionMethods" Version="2.0.0" />

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Startup.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Startup.cs
@@ -103,7 +103,7 @@ public class Startup
 
       if (Directory.Exists(dpTargetPath)) {
          // If a Key Vault Key URI is defined, expect to encrypt the keys.xml
-         string? kvProtectionKeyUri = Configuration.GetValue<string>("DataProtection:KeyVaultKey");
+         string kvProtectionKeyUri = Configuration.GetValue<string>("DataProtection:KeyVaultKey");
 
          // Setup basic Data Protection and persist keys.xml to local file system
          var dp = services.AddDataProtection().PersistKeysToFileSystem(new DirectoryInfo(dpTargetPath));

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Utils/DataProtectionService.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Utils/DataProtectionService.cs
@@ -1,0 +1,31 @@
+using Azure.Identity;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.DataProtection;
+using System;
+using System.IO;
+
+namespace Dfe.PrepareConversions.Utils
+{
+   internal static class DataProtectionService
+   {
+      public static void AddDataProtectionService(this IServiceCollection services, IConfiguration configuration)
+      {
+         var dp = services.AddDataProtection();
+         var dpTargetPath = "@/srv/app/storage";
+
+         if (Directory.Exists(dpTargetPath)) {
+            // If a Key Vault Key URI is defined, expect to encrypt the keys.xml
+            string kvProtectionKeyUri = configuration.GetValue<string>("DataProtection:KeyVaultKey");
+
+            if (!string.IsNullOrWhiteSpace(kvProtectionKeyUri))
+            {
+               throw new InvalidOperationException("DataProtection:Path is undefined or empty");
+            }
+
+            dp.PersistKeysToFileSystem(new DirectoryInfo(dpTargetPath));
+            dp.ProtectKeysWithAzureKeyVault(new Uri(kvProtectionKeyUri), new DefaultAzureCredential());
+         }
+      }
+   }
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -181,6 +181,7 @@ No resources.
 | <a name="input_enable_cdn_frontdoor"></a> [enable\_cdn\_frontdoor](#input\_enable\_cdn\_frontdoor) | Enable Azure CDN Front Door. This will use the Container Apps endpoint as the origin. | `bool` | n/a | yes |
 | <a name="input_enable_cdn_frontdoor_health_probe"></a> [enable\_cdn\_frontdoor\_health\_probe](#input\_enable\_cdn\_frontdoor\_health\_probe) | Enable CDN Front Door health probe | `bool` | `false` | no |
 | <a name="input_enable_cdn_frontdoor_vdp_redirects"></a> [enable\_cdn\_frontdoor\_vdp\_redirects](#input\_enable\_cdn\_frontdoor\_vdp\_redirects) | Deploy redirects for security.txt and thanks.txt to an external Vulnerability Disclosure Program service | `bool` | `true` | no |
+| <a name="input_enable_container_app_file_share"></a> [enable\_container\_app\_file\_share](#input\_enable\_container\_app\_file\_share) | Create an Azure Storage Account and File Share to be mounted to the Container Apps | `bool` | `false` | no |
 | <a name="input_enable_container_registry"></a> [enable\_container\_registry](#input\_enable\_container\_registry) | Set to true to create a container registry | `bool` | n/a | yes |
 | <a name="input_enable_dns_zone"></a> [enable\_dns\_zone](#input\_enable\_dns\_zone) | Conditionally create a DNS zone | `bool` | n/a | yes |
 | <a name="input_enable_event_hub"></a> [enable\_event\_hub](#input\_enable\_event\_hub) | Send Azure Container App logs to an Event Hub sink | `bool` | `false` | no |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -139,6 +139,7 @@ No providers.
 |------|--------|---------|
 | <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v1.15.0 |
 | <a name="module_azurerm_key_vault"></a> [azurerm\_key\_vault](#module\_azurerm\_key\_vault) | github.com/DFE-Digital/terraform-azurerm-key-vault-tfvars | v0.5.0 |
+| <a name="module_data_protection"></a> [data\_protection](#module\_data\_protection) | github.com/DFE-Digital/terraform-azurerm-aspnet-data-protection | v1.0.1 |
 | <a name="module_statuscake-tls-monitor"></a> [statuscake-tls-monitor](#module\_statuscake-tls-monitor) | github.com/dfe-digital/terraform-statuscake-tls-monitor | v0.1.4 |
 
 ## Resources

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -32,6 +32,7 @@ module "azure_container_apps_hosting" {
   enable_health_insights_api             = local.enable_health_insights_api
   health_insights_api_cors_origins       = local.health_insights_api_cors_origins
   health_insights_api_ipv4_allow_list    = local.health_insights_api_ipv4_allow_list
+  enable_container_app_file_share        = local.enable_container_app_file_share
 
   enable_cdn_frontdoor                            = local.enable_cdn_frontdoor
   cdn_frontdoor_forwarding_protocol               = local.cdn_frontdoor_forwarding_protocol

--- a/terraform/data-protection.tf
+++ b/terraform/data-protection.tf
@@ -1,0 +1,11 @@
+module "data_protection" {
+  source = "github.com/DFE-Digital/terraform-azurerm-aspnet-data-protection?ref=v1.0.1"
+
+  data_protection_key_vault_assign_role   = false
+  data_protection_key_vault_subnet_prefix = "172.16.100.0/28"
+  data_protection_key_vault_access_ipv4   = local.key_vault_access_ipv4
+  data_protection_resource_prefix         = "${local.environment}${local.project_name}"
+  data_protection_azure_location          = local.azure_location
+  data_protection_tags                    = local.tags
+  data_protection_resource_group_name     = module.azure_container_apps_hosting.azurerm_resource_group_default.name
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -55,4 +55,5 @@ locals {
   health_insights_api_ipv4_allow_list             = var.health_insights_api_ipv4_allow_list
   enable_cdn_frontdoor_vdp_redirects              = var.enable_cdn_frontdoor_vdp_redirects
   cdn_frontdoor_vdp_destination_hostname          = var.cdn_frontdoor_vdp_destination_hostname
+  enable_container_app_file_share                 = var.enable_container_app_file_share
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -370,3 +370,9 @@ variable "cdn_frontdoor_vdp_destination_hostname" {
   type        = string
   default     = "vdp.security.education.gov.uk"
 }
+
+variable "enable_container_app_file_share" {
+  description = "Create an Azure Storage Account and File Share to be mounted to the Container Apps"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
The purpose of this Pull Request is to add aspnet Data Protection services to the webapp. This will ensure that user sessions are secured and persistent across multiple 'instances' of the web app. This is particularly important in Azure where the app is running in containers.

As you will see in the logic of the patch, this is not testable on a local machine due to requiring access to a linux file path and Azure Key Vault Key. 

Mounting a network-attached File Share to all the containers that run the app, then storing the session key ring `key.xml` on the shared file path, will ensure all instances of the app can use the same key for encrypting/decrypting user sessions.

## Changes

- Registers Data Protection services to the app
- Allows operators to deploy a File Share using Terraform
- Allows operators to deploy a Key Vault and associated cryptographic Key used to further encrypt the aspnet key ring on the File Share
