### PR TITLE
Remove unused cypress package

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/package-lock.json
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/package-lock.json
@@ -18,7 +18,6 @@
         "@cypress/webpack-preprocessor": "^6.0.1",
         "cypress": "^13.6.2",
         "cypress-axe": "^1.2.0",
-        "cypress-data-session": "^1.13.0",
         "cypress-localstorage-commands": "^2.0.0",
         "cypress-plugin-api": "^2.10.3",
         "cypress-slack-reporter": "^1.5.3",
@@ -3762,16 +3761,6 @@
         "cypress": "^10 || ^11 || ^12 || ^13"
       }
     },
-    "node_modules/cypress-data-session": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/cypress-data-session/-/cypress-data-session-1.15.1.tgz",
-      "integrity": "sha512-GLldWnVFKnjXd1fl7NapbD8ruogN51LuhZKQLT/Gq8JDVxnskd/eg5vgfyLBwQiUmlcFjY0LME9Oej5osaIq5Q==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.2",
-        "simple-sha256": "^1.1.0"
-      }
-    },
     "node_modules/cypress-localstorage-commands": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/cypress-localstorage-commands/-/cypress-localstorage-commands-2.2.6.tgz",
@@ -7113,26 +7102,6 @@
       "engines": {
         "node": ">=14.16"
       }
-    },
-    "node_modules/simple-sha256": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/simple-sha256/-/simple-sha256-1.1.0.tgz",
-      "integrity": "sha512-jMdj+5MR1dRiFbrQ8idmkPv+HCoJEmJVBBwc0vQQz4Gtg3PEkjdpVxUM4BSwK898zhNP/ub3vcP9edw47EHuLQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -10800,16 +10769,6 @@
       "dev": true,
       "requires": {}
     },
-    "cypress-data-session": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/cypress-data-session/-/cypress-data-session-1.15.1.tgz",
-      "integrity": "sha512-GLldWnVFKnjXd1fl7NapbD8ruogN51LuhZKQLT/Gq8JDVxnskd/eg5vgfyLBwQiUmlcFjY0LME9Oej5osaIq5Q==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.3.2",
-        "simple-sha256": "^1.1.0"
-      }
-    },
     "cypress-localstorage-commands": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/cypress-localstorage-commands/-/cypress-localstorage-commands-2.2.6.tgz",
@@ -13299,12 +13258,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/simple-bin-help/-/simple-bin-help-1.8.0.tgz",
       "integrity": "sha512-0LxHn+P1lF5r2WwVB/za3hLRIsYoLaNq1CXqjbrs3ZvLuvlWnRKrUjEWzV7umZL7hpQ7xULiQMV+0iXdRa5iFg==",
-      "dev": true
-    },
-    "simple-sha256": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/simple-sha256/-/simple-sha256-1.1.0.tgz",
-      "integrity": "sha512-jMdj+5MR1dRiFbrQ8idmkPv+HCoJEmJVBBwc0vQQz4Gtg3PEkjdpVxUM4BSwK898zhNP/ub3vcP9edw47EHuLQ==",
       "dev": true
     },
     "slash": {

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/package.json
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/package.json
@@ -46,7 +46,6 @@
     "@cypress/webpack-preprocessor": "^6.0.1",
     "cypress": "^13.6.2",
     "cypress-axe": "^1.2.0",
-    "cypress-data-session": "^1.13.0",
     "cypress-localstorage-commands": "^2.0.0",
     "cypress-plugin-api": "^2.10.3",
     "cypress-slack-reporter": "^1.5.3",


### PR DESCRIPTION
Off the back of #1130, removing package no longer in use in Cypress tests