### PR TITLE
HTTP Security headers

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Security/SecureHeadersDefinitions.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Security/SecureHeadersDefinitions.cs
@@ -12,7 +12,6 @@ public static class SecurityHeadersDefinitions
    {
       HeaderPolicyCollection policy = new HeaderPolicyCollection()
          .AddFrameOptionsDeny()
-         .AddXssProtectionBlock()
          .AddContentTypeOptionsNoSniff()
          .AddReferrerPolicyStrictOriginWhenCrossOrigin()
          .RemoveServerHeader()
@@ -59,7 +58,8 @@ public static class SecurityHeadersDefinitions
             builder.AddPictureInPicture().None();
             builder.AddSyncXHR().None();
             builder.AddUsb().None();
-         });
+         })
+         .AddXssProtectionDisabled();
 
       return policy;
    }

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Security/SecureHeadersDefinitions.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Security/SecureHeadersDefinitions.cs
@@ -43,7 +43,6 @@ public static class SecurityHeadersDefinitions
             builder.AddScriptSrc().From(ApplicationInsightsUri).UnsafeInline().WithNonce();
             builder.AddFrameAncestors().None();
          })
-         .RemoveServerHeader()
          .AddPermissionsPolicy(builder =>
          {
             builder.AddAccelerometer().None();

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Security/SecureHeadersDefinitions.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Security/SecureHeadersDefinitions.cs
@@ -62,12 +62,6 @@ public static class SecurityHeadersDefinitions
             builder.AddUsb().None();
          });
 
-      if (!isDev)
-      {
-         // max age = one year in seconds
-         policy.AddStrictTransportSecurityMaxAgeIncludeSubDomains(maxAgeInSeconds: 60 * 60 * 24 * 365);
-      }
-
       return policy;
    }
 }

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Startup.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Startup.cs
@@ -182,10 +182,7 @@ public class Startup
          app.UseHsts();
       }
 
-      app.UseSecurityHeaders(
-         SecurityHeadersDefinitions.GetHeaderPolicyCollection(env.IsDevelopment())
-            .AddXssProtectionDisabled()
-      );
+      app.UseSecurityHeaders(SecurityHeadersDefinitions.GetHeaderPolicyCollection(env.IsDevelopment()));
 
       app.UseCookiePolicy(new CookiePolicyOptions { Secure = CookieSecurePolicy.Always, HttpOnly = HttpOnlyPolicy.Always });
 

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Startup.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Startup.cs
@@ -79,6 +79,15 @@ public class Startup
       services.AddControllersWithViews()
          .AddMicrosoftIdentityUI();
 
+      // Enforce HTTPS in ASP.NET Core
+      // @link https://learn.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?
+      services.AddHsts(options =>
+      {
+         options.Preload = true;
+         options.IncludeSubDomains = true;
+         options.MaxAge = TimeSpan.FromDays(365);
+      });
+
       services.AddScoped(sp => sp.GetService<IHttpContextAccessor>()?.HttpContext?.Session);
       services.AddSession(options =>
       {

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Startup.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Startup.cs
@@ -172,6 +172,15 @@ public class Startup
 
    public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)
    {
+      // Ensure we do not lose X-Forwarded-* Headers when behind a Proxy
+      var forwardOptions = new ForwardedHeadersOptions {
+         ForwardedHeaders = ForwardedHeaders.All,
+         RequireHeaderSymmetry = false
+      };
+      forwardOptions.KnownNetworks.Clear();
+      forwardOptions.KnownProxies.Clear();
+      app.UseForwardedHeaders(forwardOptions);
+
       if (env.IsDevelopment())
       {
          app.UseDeveloperExceptionPage();
@@ -179,10 +188,10 @@ public class Startup
       else
       {
          app.UseExceptionHandler("/Errors");
-         app.UseHsts();
       }
 
       app.UseSecurityHeaders(SecurityHeadersDefinitions.GetHeaderPolicyCollection(env.IsDevelopment()));
+      app.UseHsts();
 
       app.UseCookiePolicy(new CookiePolicyOptions { Secure = CookieSecurePolicy.Always, HttpOnly = HttpOnlyPolicy.Always });
 
@@ -190,12 +199,6 @@ public class Startup
 
       app.UseHttpsRedirection();
       app.UseHealthChecks("/health");
-
-      //For Azure AD redirect uri to remain https
-      ForwardedHeadersOptions forwardOptions = new() { ForwardedHeaders = ForwardedHeaders.All, RequireHeaderSymmetry = false };
-      forwardOptions.KnownNetworks.Clear();
-      forwardOptions.KnownProxies.Clear();
-      app.UseForwardedHeaders(forwardOptions);
 
       app.UseStaticFiles();
       app.UseRouting();

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Startup.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Startup.cs
@@ -158,7 +158,7 @@ public class Startup
       // Initialize the TransfersUrl
       var serviceLinkOptions = Configuration.GetSection("ServiceLink").Get<ServiceLinkOptions>();
       Links.InitializeTransfersUrl(serviceLinkOptions.TransfersUrl);
-      
+
    }
 
    public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)
@@ -170,7 +170,6 @@ public class Startup
       else
       {
          app.UseExceptionHandler("/Errors");
-         // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
          app.UseHsts();
       }
 


### PR DESCRIPTION
A few of the HTTP Header definitions were duplicated or misconfigured.

* Sets X-Xss-Protection to 0 and removes duplicate call
* Removes duplicate HSTS header call and sets it using the aspnet approach
* Formats the document consistently using .editorconfig