### PR TITLE
removing 'add conversions' to group question and success banner when creating new group

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Groups/CheckConversionDetails.cshtml.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Groups/CheckConversionDetails.cshtml.cs
@@ -49,9 +49,7 @@ public class CheckConversionDetailsModel : PageModel
       var newGroup = new CreateProjectGroup(trust.ReferenceNumber, trust.Ukprn, trust.Name, selectedconversions.ConvertAll(int.Parse));
 
       var newGroupResponse = _projectGroupsRepository.CreateNewProjectGroup(newGroup);
-
-      //var newGroupConversions = newGroupResponse.Result.Body.Projects;
       
-      return RedirectToPage(Links.ProjectGroups.CreateANewGroup.Page, new { ukprn});
+      return RedirectToPage(Links.ProjectGroups.ProjectGroupIndex.Page, new { newGroupResponse.Result.Body.Id, isNew = true });
    }
 }

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Groups/CheckIncomingTrustsDetails.cshtml.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Groups/CheckIncomingTrustsDetails.cshtml.cs
@@ -42,6 +42,6 @@ public class CheckIncomingTrustsDetailsModel : PageModel
    
    public async Task<IActionResult> OnPost(string ukprn)
    {
-      return RedirectToPage(Links.ProjectGroups.DoYouWantToAddConversions.Page, new { ukprn });
+      return RedirectToPage(Links.ProjectGroups.SelectConversions.Page, new { ukprn });
    }
 }

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Groups/ProjectGroupIndex.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Groups/ProjectGroupIndex.cshtml
@@ -1,4 +1,4 @@
-﻿@page "/groups/school-in-group{id:int}"
+﻿@page "/groups/school-in-group/{id:int}"
 @using Dfe.Academisation.ExtensionMethods
 @model Dfe.PrepareConversions.Pages.Groups.ProjectGroupIndex
 @{
@@ -9,6 +9,19 @@
 {
     <a asp-page="@Links.ProjectList.ProjectGroups.Page" class="govuk-back-link">@Links.ProjectList.ProjectGroups.BackText</a>
 }
+<div if="Model.IsNew" class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+     data-cy="select-projectlist-filter-banner">
+    <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Success
+        </h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <h3 class="govuk-notification-banner__heading">
+            Project group created.
+        </h3>
+    </div>
+</div>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Groups/ProjectGroupIndex.cshtml.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Groups/ProjectGroupIndex.cshtml.cs
@@ -25,10 +25,12 @@ public class ProjectGroupIndex : PageModel
 
    public List<ProjectListViewModel> Projects { get; set; }
    public List<ProjectStatus> Statuses { get; set; }
+   public bool IsNew { get; private set; }
 
-   public async Task<IActionResult> OnGetAsync(int id)
+   public async Task<IActionResult> OnGetAsync(int id, bool isNew = false)
    {
       IActionResult result = await SetProjectGroup(id);
+      IsNew = isNew;
       Projects = ProjectGroup.Projects.Select(AcademyConversionProject => ProjectListHelper.Build(AcademyConversionProject)).ToList();
       Statuses = GetProjectStatuses();
       if ((result as StatusCodeResult)?.StatusCode == (int)HttpStatusCode.NotFound)
@@ -43,7 +45,7 @@ public class ProjectGroupIndex : PageModel
    protected async Task<IActionResult> SetProjectGroup(int id)
    {
       var ProjectGroupResponse = await _repository.GetProjectGroupById(id);
-
+      
       if (!ProjectGroupResponse.Success)
       {
          // 404 logic


### PR DESCRIPTION
removing 'add conversions' to group question and success banner when creating new group