### PR TITLE
Set HTTP user agent header

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Startup.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Startup.cs
@@ -126,6 +126,7 @@ public class Startup
          TramsApiOptions tramsApiOptions = GetTypedConfigurationFor<TramsApiOptions>();
          client.BaseAddress = new Uri(tramsApiOptions.Endpoint);
          client.DefaultRequestHeaders.Add("ApiKey", tramsApiOptions.ApiKey);
+         client.DefaultRequestHeaders.Add("User-Agent", "PrepareConversions/1.0");
 
       });
 
@@ -134,6 +135,7 @@ public class Startup
          AcademisationApiOptions apiOptions = GetTypedConfigurationFor<AcademisationApiOptions>();
          client.BaseAddress = new Uri(apiOptions.BaseUrl);
          client.DefaultRequestHeaders.Add("x-api-key", apiOptions.ApiKey);
+         client.DefaultRequestHeaders.Add("User-Agent", "PrepareConversions/1.0");
       });
 
       services.Configure<ServiceLinkOptions>(GetConfigurationSectionFor<ServiceLinkOptions>());


### PR DESCRIPTION
Set a custom User-Agent HTTP Header so that traffic can be segmented when running reports against the downstream APIs