### PR TITLE
fix for validation that is not required on conversion details page

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/UpdateAcademyConversionProjectPageModel.cs
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/UpdateAcademyConversionProjectPageModel.cs
@@ -37,12 +37,6 @@ public class UpdateAcademyConversionProjectPageModel : BaseAcademyConversionProj
 
       bool schoolAndTrustInformationSectionComplete = AcademyConversionProject.SchoolAndTrustInformationSectionComplete != null &&
                                                       AcademyConversionProject.SchoolAndTrustInformationSectionComplete.Value;
-      if (schoolAndTrustInformationSectionComplete && !Project.HeadTeacherBoardDate.HasValue)
-      {
-         _errorService.AddError(
-            $"/task-list/{id}/confirm-school-trust-information-project-dates/advisory-board-date?return=%2FTaskList%2FSchoolAndTrustInformation/ConfirmSchoolAndTrustInformation&fragment=advisory-board-date",
-            "Set an Advisory board date before you generate your project template");
-      }
 
       if (AcademyConversionProject.LocalAuthorityInformationTemplateSentDate.HasValue &&
          AcademyConversionProject.LocalAuthorityInformationTemplateReturnedDate.HasValue &&


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/67282294-5f4f-48d9-bedf-cea4b05fd2e3)

Advisory date is no longer entered on this page so the validation needs removing
