### PR TITLE
Refactored Cypress tests and added tests for Decisions to ensure the project is sent to complete

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/e2e/Core-journeys/decisions_tests.cy.js
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/e2e/Core-journeys/decisions_tests.cy.js
@@ -48,8 +48,11 @@ describe('Decisions Tests', () => {
       Logger.log("Click on record a decision menubar button");
       decisionPage.clickRecordDecisionMenu();
 
-      Logger.log("Click on record a decision button");
+      Logger.log("Click on record a decision button and add a decision to check error handling");
       decisionPage.clickRecordDecision();
+
+      decisionPage.makeDecision("approved")
+
 
       Logger.log("Check error and add necessary details to record the decision");
       decisionPage.checkErrorAndAddDetails('15', '10', '2024', 'Paul Lockwood');
@@ -57,11 +60,11 @@ describe('Decisions Tests', () => {
       Logger.log("Click on record a decision menubar button");
       decisionPage.clickRecordDecisionMenu();
 
-      Logger.log("Click on record a decision button");
-      decisionPage.clickRecordDecisionWithoutError();
+      
 
       Logger.log("Record the decision with the necessary details");
-      decisionPage.makeDecision("deferred")
+      decisionPage.clickRecordDecisionWithoutError()
+      .makeDecision("deferred")
         .decsionMaker("grade6")
         .selectReasonWhyDeferred()
         .enterDecisionMakerName('Fahad Darwish')

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/pages/decisionPage.js
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/pages/decisionPage.js
@@ -41,7 +41,7 @@ export class DecisionPage {
     }
 
     clickRecordDecision() {
-        cy.get('[data-test="record_decision_error_btn"]').click();
+        cy.get('[data-cy="record_decision_btn"]').click();
         return this;
     }
 
@@ -52,20 +52,31 @@ export class DecisionPage {
 
 
     checkErrorAndAddDetails(day, month, year, userName) {
-
-        cy.get('#errorSummary').should('be.visible');
+        cy.get('.govuk-error-summary').should('be.visible');
         cy.get('#error-summary-title').should('contain', 'There is a problem');
         cy.get('[data-cy="error-summary"]')
             .find('a')
-            .should('have.length', 2)
+            .should('have.length', 4)
             .eq(0)
-            .should('contain', 'You must enter an advisory board date before you can record a decision.')
+            .should('contain', 'You must enter the name of the person who worked on this project before you can record a decision.')
             .and('be.visible');
         cy.get('[data-cy="error-summary"]')
             .find('a')
             .eq(1)
-            .should('contain', 'You must enter the name of the person who worked on this project before you can record a decision.')
+            .should('contain', 'You must enter a proposed conversion date before you can record a decision.')
             .and('be.visible');
+        cy.get('[data-cy="error-summary"]')
+            .find('a')
+            .eq(2)
+            .should('contain', 'You must enter trust name before you can record a decision.')
+            .and('be.visible');
+        cy.get('[data-cy="error-summary"]')
+            .find('a')
+            .eq(3)
+            .should('contain', 'You must enter an advisory board date before you can record a decision.')
+            .and('be.visible');
+
+        // Clicking and filling fields as per the error messages
         cy.contains('a', 'You must enter an advisory board date before you can record a decision').click();
         cy.get('#head-teacher-board-date-day').type(day);
         cy.get('#head-teacher-board-date-month').type(month);
@@ -74,22 +85,48 @@ export class DecisionPage {
 
         cy.get('[data-cy="record_decision_menu"] > .moj-sub-navigation__link').click();
 
+        cy.get('[data-cy="record_decision_btn"]').click();
+        cy.get('#approved-radio').click();
+        cy.get('#submit-btn').click();
 
-        cy.get('[data-test="record_decision_error_btn"]').click();
         cy.contains('a', 'You must enter the name of the person who worked on this project before you can record a decision.').click();
         cy.get('#delivery-officer').type(userName);
         cy.get('.autocomplete__option').first().click();
         cy.get('[data-cy="continue-Btn"]').click();
 
 
+        // Verifying notification messages
         cy.get('#notification-message').should('include.text', 'Project is assigned');
         cy.get('#main-content > :nth-child(2) > :nth-child(2)').should('include.text', userName);
+
+        cy.get('[data-cy="record_decision_menu"] > .moj-sub-navigation__link').click();
+        cy.get('[data-cy="record_decision_btn"]').click();
+        cy.get('#approved-radio').click();
+        cy.get('#submit-btn').click();
+
+        cy.contains('a', 'You must enter a proposed conversion date before you can record a decision.').click();
+        cy.get('#proposed-conversion-month').type(month);
+        cy.get('#proposed-conversion-year').type(year);
+        cy.get('[data-cy="select-common-submitbutton"]').click();
+        cy.get('#confirm-and-continue-button').click();
+
+        cy.get('[data-cy="record_decision_menu"] > .moj-sub-navigation__link').click();
+        cy.get('[data-cy="record_decision_btn"]').click();
+        cy.get('#approved-radio').click();
+        cy.get('#submit-btn').click();
+
+        cy.contains('a', 'You must enter trust name before you can record a decision.').click();
+        cy.get('.autocomplete__wrapper > #SearchQuery').type('10058252');
+        cy.get('#SearchQuery__option--0').click();
+        cy.get('button.govuk-button[data-id="submit"]').click();
 
         return this;
     }
 
 
+
     makeDecision(decision) {
+
         cy.get(`#${decision}-radio`).click();
         cy.get('#submit-btn').click();
         return this;


### PR DESCRIPTION
Title: Refactored Cypress Tests and Added Tests for Decisions to Ensure Project is Sent to Complete

This PR refactors existing Cypress tests and adds new tests for the "Decisions" functionality to ensure that projects transition correctly from "Prepare" to "Complete." Tests cover various project types to validate data transfer and project creation in Complete.

Please note, we only tested the conversion part via Cypress; the Complete section was tested manually to ensure the project appears there.