### PR TITLE
Updated renovate.json to use the shared renovate config repository

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,27 +1,4 @@
 {
    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-   "extends": [
-     "config:recommended",
-     "group:linters",
-     "group:test",
-     "schedule:weekly",
-     ":approveMajorUpdates",
-     ":automergeLinters",
-     ":automergePatch",
-     ":automergePr",
-     ":automergeRequireAllStatusChecks",
-     ":automergeTesters",
-     ":maintainLockFilesWeekly",
-     ":dependencyDashboard"
-   ],
-   "timezone": "Europe/London",
-   "minimumReleaseAge": "7 days",
-   "automergeSchedule": ["after 10am every weekday", "before 4pm every weekday"],
-   "labels": ["dependencies", "renovate"],
-   "vulnerabilityAlerts": {
-     "addLabels": ["security"]
-   },
-   "major": {
-     "addLabels": ["major"]
-   }
- }
+   "extends": [ "github>DFE-Digital/rsd-renovate-config" ]
+}


### PR DESCRIPTION
- Updated renovate.json to use the shared renovate config repository
This is required to ensure we are not accidentally or automatically upgrade FluentAssertion to v8. The update will limit the version to v7.0.0.