### PR TITLE
refactoring cookies test for Transfers

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/e2e/transfers/cookiePolicy.cy.ts
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions.CypressTests/cypress/e2e/transfers/cookiePolicy.cy.ts
@@ -21,7 +21,8 @@ describe('Cookie Policy', () => {
     });
 
     it('Should hide the cookie banner when consent has been given', () => {
-      cy.get("#acceptCookieBanner").should('have.css', 'display', 'block');  // Ensure the new acceptance message is visible
+      cy.get("#acceptCookieBanner").should('be.visible');
+
 
     });
   })


### PR DESCRIPTION
This PR updates the **Cypress test for cookie banner visibility** in the Transfers module by replacing a **CSS-based assertion** with a **Cypress-native visibility check** for better reliability.  

---

#### **🔧 Changes Made**
✅ **Replaced**  
```javascript
cy.get("#acceptCookieBanner").should('have.css', 'display', 'block');
```
**with**
```javascript
cy.get("#acceptCookieBanner").should('be.visible');
```
✅ Ensures **better readability** and aligns with **Cypress best practices**.  
✅ Prevents reliance on CSS properties (`display: block`), which can change due to styling updates.  
