### PR TITLE
Wait for quality gate response from Sonar before finishing the workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         ConnectionStrings__RedisCache: "redis:6379,ssl=False,abortConnect=False"
       run: |
-        dotnet-sonarscanner begin /d:sonar.scanner.skipJreProvisioning=true /k:"DFE-Digital-prepare-academy-conversions" /o:"dfe-digital" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.coverageReportPaths=./Dfe.PrepareConversions/CoverageReport/SonarQube.xml
+        dotnet-sonarscanner begin /d:sonar.scanner.skipJreProvisioning=true /d:sonar.qualitygate.wait=true /k:"DFE-Digital-prepare-academy-conversions" /o:"dfe-digital" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.coverageReportPaths=./Dfe.PrepareConversions/CoverageReport/SonarQube.xml
         dotnet build Dfe.PrepareConversions/Dfe.PrepareConversions.sln --no-restore
         dotnet test Dfe.PrepareConversions/Dfe.PrepareConversions.sln --no-build --verbosity normal --collect:"XPlat Code Coverage"
         reportgenerator -reports:"./**/coverage.cobertura.xml" -targetdir:./Dfe.PrepareConversions/CoverageReport -reporttypes:SonarQube


### PR DESCRIPTION
This forms part of the work to make Sonarqube a mandatory quality gate.
Introducing the `sonar.qualitygate.wait=true` parameter ensures that the scanner will wait for the report to be generated and will fail the workflow if the gate is red, rather than completing the workflow regardless of the gate