### PR TITLE
Tweaks to Header component

### DIFF
--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/_Layout.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/_Layout.cshtml
@@ -108,8 +108,8 @@
         <div class="dfe-width-container dfe-header__container">
             <div class="dfe-header__logo">
                 <a asp-page="@Links.ProjectList.Index.Page" class="dfe-header__link">
-                    <img src="~/src/images/dfe-logo.png" class="dfe-logo" alt="Department for Education">
-                    <img src="~/src/images/dfe-logo-alt.png" class="dfe-logo-hover" alt="Department for Education">
+                    <img src="~/assets/dfe-logo.png" class="dfe-logo" alt="Department for Education">
+                    <img src="~/assets/dfe-logo-alt.png" class="dfe-logo-hover" alt="Department for Education">
                 </a>
                 <a href="/" class="dfe-header__link--service govuk-link">Prepare conversions and transfers</a>
             </div>

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/_Layout.cshtml
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/Pages/Shared/_Layout.cshtml
@@ -111,8 +111,10 @@
                     <img src="~/assets/dfe-logo.png" class="dfe-logo" alt="Department for Education">
                     <img src="~/assets/dfe-logo-alt.png" class="dfe-logo-hover" alt="Department for Education">
                 </a>
-                <a href="/" class="dfe-header__link--service govuk-link">Prepare conversions and transfers</a>
             </div>
+        </div>
+        <div class="dfe-width-container dfe-header__service-name">
+            <a href="/" class="dfe-header__link--service">Prepare conversions and transfers</a>
         </div>
         <nav class="dfe-header__navigation" id="header-navigation" role="navigation" aria-label="Primary navigation" aria-labelledby="label-navigation">
             <div class="dfe-width-container">

--- a/Dfe.PrepareConversions/Dfe.PrepareConversions/wwwroot/webpack.assets.config.js
+++ b/Dfe.PrepareConversions/Dfe.PrepareConversions/wwwroot/webpack.assets.config.js
@@ -8,6 +8,7 @@ module.exports = {
 				{ from: path.join(__dirname, 'node_modules/govuk-frontend/govuk/assets'), to: path.join(__dirname, 'assets') },
 				{ from: path.join(__dirname, 'node_modules/accessible-autocomplete/dist'), to: path.join(__dirname, 'dist') },
             { from: path.join(__dirname, 'node_modules/dfe-frontend/dist'), to: path.join(__dirname, 'dist') },
+            { from: path.join(__dirname, 'node_modules/dfe-frontend/packages/assets'), to: path.join(__dirname, 'assets') },
 				{ from: path.resolve(__dirname, 'node_modules/@ministryofjustice/frontend/moj/assets'), to: path.resolve(__dirname, 'assets') },
 			],
 		})


### PR DESCRIPTION
- The logo assets were from the older version of the DFE Frontend kit and were invalid so now the build assets webpack config will be responsible for bringing in the latest logos
- Took the site name out of the site logo component so it sits on its own