### PR TITLE
Improve .gitignore: clarify .builds rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,9 @@ StyleCopReport.xml
 *.log
 *.vspscc
 *.vssscc
+# Ignore .build file or folder(used for build metadata or CI tools)
 .builds
+.builds/
 *.pidb
 *.svclog
 *.scc


### PR DESCRIPTION
Added a comment to explain the purpose of .builds rule  and included both file and directory  ignore patterns to ensure full coverage. This helps others understand what is  being ignored and why.